### PR TITLE
Simple CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,3 +56,12 @@ jobs:
           LIGO="$LIGO_EXE" \
           EXTRA_STACK_OPTIONS="--system-ghc --ghc-options=-Werror" \
           TEST_ARGUMENTS="--nettest-no-run-network"
+
+  links-check:
+    name: Verify links in markdown documentation
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - uses: serokell/xrefcheck-action@v1
+      with:
+        xrefcheck-version: 0.1.3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,58 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches: [main, develop]
+
+env:
+  LIGO_VERSION: 0.12.0
+  LIGO_EXE: >-
+    docker run --rm -v "$$GITHUB_WORKSPACE":"$$GITHUB_WORKSPACE" -w "$$PWD" ligolang/ligo:$$LIGO_VERSION
+
+jobs:
+
+  # Build LIGO contracts
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+      if: github.event.action == 'opened' || github.event.action == 'synchronize' || github.event.ref == 'refs/heads/main' || github.event.ref == 'refs/heads/develop'
+
+    - name: Swaps contract
+      run: |
+        make -C contracts/ligo/src/swaps clean
+        make -C contracts/ligo/src/swaps LIGO="$LIGO_EXE"
+
+  # Test LIGO contracts (whose that are covered with cleveland)
+  test-cleveland:
+    name: Cleveland tests
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+      if: github.event.action == 'opened' || github.event.action == 'synchronize' || github.event.ref == 'refs/heads/main' || github.event.ref == 'refs/heads/develop'
+
+    - uses: actions/cache@v1
+      name: Cache ~/.stack
+      with:
+        path: ~/.stack
+        key: stack
+
+    - uses: actions/setup-haskell@v1.1.4
+      name: Setup Haskell Stack
+      with:
+        ghc-version: 9.0.1  # higher than necessary, but is cached in the runner
+        stack-version: 2.3
+
+    - name: Build dependencies
+      run: make -C contracts/test-hs build-haskell-deps
+
+    - name: Tests in emulation
+      run: |
+        make -C contracts/test-hs \
+          LIGO="$LIGO_EXE" \
+          EXTRA_STACK_OPTIONS="--system-ghc --ghc-options=-Werror" \
+          TEST_ARGUMENTS="--nettest-no-run-network"

--- a/.xrefcheck.yaml
+++ b/.xrefcheck.yaml
@@ -1,0 +1,50 @@
+# SPDX-FileCopyrightText: 2019 Serokell <https://serokell.io>
+#
+# SPDX-License-Identifier: Unlicense
+
+# Parameters of repository traversal.
+traversal:
+  # Files and folders which we pretend do not exist
+  # (so they are neither analyzed nor can be referenced).
+  ignored:
+    # Git files
+    - .git
+
+    # Stack files
+    - contracts/test-hs/.stack-work
+
+    # JS files
+    - node_modules
+
+# Verification parameters.
+verification:
+  # On 'anchor not found' error, how much similar anchors should be displayed as
+  # hint. Number should be between 0 and 1, larger value means stricter filter.
+  anchorSimilarityThreshold: 0.5
+
+  # When checking external references, how long to wait on request before
+  # declaring "Response timeout".
+  externalRefCheckTimeout: 10s
+
+  # Prefixes of files, references in which should not be analyzed.
+  notScanned:
+    # GitHub-specific files
+    - .github/pull_request_template.md
+    - .github/issue_template.md
+    - .github/PULL_REQUEST_TEMPLATE
+    - .github/ISSUE_TEMPLATE
+
+  # Glob patterns describing the files which do not physically exist in the
+  # repository but should be treated as existing nevertheless.
+  virtualFiles:
+    # GitHub pages
+    - ../../../issues
+    - ../../../issues/*
+    - ../../../pulls
+    - ../../../pulls/*
+
+  # POSIX extended regular expressions that match external references
+  # that have to be ignored (not verified).
+  # It is an optional parameter, so it can be omitted.
+  ignoreRefs:
+    []

--- a/contracts/ligo/src/swaps/Makefile
+++ b/contracts/ligo/src/swaps/Makefile
@@ -1,6 +1,8 @@
 .PHONY: swap-storage clean
 
-# Ligo executable
+# Ligo executable.
+# To build with docker, pass
+# LIGO="docker run --rm -v \"$PWD\":\"$PWD\" -w \"\$(shell pwd)\" ligolang/ligo:0.11.0"
 LIGO ?= ligo
 
 # Compile code

--- a/contracts/test-hs/Makefile
+++ b/contracts/test-hs/Makefile
@@ -2,15 +2,21 @@
 
 TEST_ARGUMENTS ?= ""
 
+EXTRA_STACK_OPTIONS ?= ""
+
 all: test
 
 # Compile contracts necessary for tests.
 compile-contracts:
 	$(MAKE) -C ../ligo/src/swaps
 
+# Build Haskell dependencies.
+build-haskell-deps:
+	stack build --only-dependencies
+
 # Build and run tests (only in emulation).
 test: compile-contracts
-	stack test minter-sdk --fast \
+	stack test minter-sdk --fast $(EXTRA_STACK_OPTIONS) \
 		--test-arguments "--color always $(TEST_ARGUMENTS)"
 
 # Run tests against a real node.


### PR DESCRIPTION
Adding some trivial CI checks here.

I do not build all the contracts nor run the Taquito tests since I have not much experience in building with `npm` / providing test environment for Taquito. Hope that everything will settle up incrementally in subsequent PRs.

The build takes less than 3 minutes, I hope this should be acceptable. Most of this time is spent in fetching dependencies from cache (mimicking `Michelson` requires a lot of dependencies), so looks like we cannot optimize further.

Also, I saw that at some moment Markdown links were used incorrectly, so I added links check with `xrefcheck` tool that is being developed by us (Serokell), in case of any issues feel free to report an issue / disable this tool (we are using it for almost a year and it turns out to be pretty helpful).