### PR TITLE
Contract compilation clean up

### DIFF
--- a/contracts/src/compile-contracts.ts
+++ b/contracts/src/compile-contracts.ts
@@ -19,10 +19,8 @@ const contractCompilers: ContractCompiler[] =
   , compileTicketNftWalletContract
   ];
 
-async function main(): Promise<void> {
+async function main(env = defaultEnv): Promise<void> {
   try {
-    const env = defaultEnv;
-
     await Promise.all(contractCompilers.map(compiler => compiler(env)));
 
     process.exit(0);

--- a/contracts/src/compile-contracts.ts
+++ b/contracts/src/compile-contracts.ts
@@ -32,7 +32,7 @@ async function main(env = defaultEnv): Promise<void> {
 
 async function compileNftFaucetContract(env: LigoEnv): Promise<void> {
   $log.info('compiling NFT faucet contract');
-  await await compileContract(
+  await compileContract(
     env,
     'minter_collection/fa2_multi_nft_faucet.mligo',
     'nft_faucet_main',
@@ -43,7 +43,7 @@ async function compileNftFaucetContract(env: LigoEnv): Promise<void> {
 
 async function compileNftContract(env: LigoEnv): Promise<void> {
   $log.info('compiling NFT contract');
-  await await compileContract(
+  await compileContract(
     env,
     'minter_collection/fa2_multi_nft_asset.mligo',
     'nft_asset_main',
@@ -55,7 +55,7 @@ async function compileNftContract(env: LigoEnv): Promise<void> {
 
 async function compileFtFaucetContract(env: LigoEnv): Promise<void> {
   $log.info('compiling FT faucet contract');
-  await await compileContract(
+  await compileContract(
     env,
     'minter_collection/fa2_multi_ft_faucet.mligo',
     'ft_faucet_main',
@@ -66,7 +66,7 @@ async function compileFtFaucetContract(env: LigoEnv): Promise<void> {
 
 async function compileFtContract(env: LigoEnv): Promise<void> {
   $log.info('compiling FT contract');
-  await await compileContract(
+  await compileContract(
     env,
     'minter_collection/fa2_multi_ft_asset.mligo',
     'multi_ft_asset_main',
@@ -78,7 +78,7 @@ async function compileFtContract(env: LigoEnv): Promise<void> {
 async function compileFixedPriceSaleMarketPlaceContract(env: LigoEnv): Promise<void> {
     $log.info('compiling fixed price sale marketplace contract');
 
-    await await compileContract(
+    await compileContract(
         env,
         'fixed_price_sale/fixed_price_sale_market.mligo',
         'fixed_price_sale_main',

--- a/contracts/src/compile-contracts.ts
+++ b/contracts/src/compile-contracts.ts
@@ -4,20 +4,26 @@ import * as fs from 'fs';
 import { defaultEnv, LigoEnv, compileContract} from './ligo';
 import { $log } from '@tsed/logger';
 
+type ContractCompiler = (env: LigoEnv) => Promise<void>;
+
+// add other contracts here
+const contractCompilers: ContractCompiler[] = 
+  [ compileNftFaucetContract
+  , compileNftContract
+  , compileFixedPriceSaleMarketPlaceContract
+  , compileFixedPriceSaleTezMarketPlaceContract
+  , compileEnglishAuctionTezContract
+  , compileFtFaucetContract
+  , compileFtContract
+  , compileTicketNftAuctionContract
+  , compileTicketNftWalletContract
+  ];
+
 async function main(): Promise<void> {
   try {
     const env = defaultEnv;
 
-    await compileNftFaucetContract(env);
-    await compileNftContract(env);
-    await compileFixedPriceSaleMarketPlaceContract(env);
-    await compileFixedPriceSaleTezMarketPlaceContract(env);
-    await compileEnglishAuctionTezContract(env);
-    await compileFtFaucetContract(env);
-    await compileFtContract(env);
-    await compileTicketNftAuctionContract(env);
-    await compileTicketNftWalletContract(env);
-    // add other contracts here
+    await Promise.all(contractCompilers.map(compiler => compiler(env)));
 
     process.exit(0);
   } catch (err) {

--- a/contracts/src/ligo.ts
+++ b/contracts/src/ligo.ts
@@ -75,7 +75,7 @@ async function compileContractImpl(
   dstFilePath: string
 ): Promise<void> {
   // const cmd = `ligo compile-contract ${srcFilePath} ${main} --output=${dstFilePath}`;
-  const cmd = `docker run --rm -v $PWD:$PWD -w $PWD ligolang/ligo:0.11.0 compile-contract ${srcFilePath} ${main} --output=${dstFilePath}  && rm bisect*.coverage`;
+  const cmd = `docker run --rm -v $PWD:$PWD -w $PWD ligolang/ligo:0.11.0 compile-contract ${srcFilePath} ${main} --output=${dstFilePath}  && rm -f bisect*.coverage`;
   await runCmd(cwd, cmd);
 }
 

--- a/contracts/src/ligo.ts
+++ b/contracts/src/ligo.ts
@@ -45,8 +45,7 @@ export async function compileAndLoadContract(
   const src = env.srcFilePath(srcFile);
   const out = env.outFilePath(dstFile);
   await compileContractImpl(env.cwd, src, main, out);
-  const code = await loadFile(out);
-  return code;
+  return loadFile(out);
 }
 
 export async function loadFile(fileName: string): Promise<string> {
@@ -57,7 +56,7 @@ export async function loadFile(fileName: string): Promise<string> {
   );
 }
 
-export async function compileContract(
+export function compileContract(
   env: LigoEnv,
   srcFile: string,
   main: string,
@@ -65,10 +64,10 @@ export async function compileContract(
 ): Promise<void> {
   const src = env.srcFilePath(srcFile);
   const out = env.outFilePath(dstFile);
-  await compileContractImpl(env.cwd, src, main, out);
+  return compileContractImpl(env.cwd, src, main, out);
 }
 
-async function compileContractImpl(
+function compileContractImpl(
   cwd: string,
   srcFilePath: string,
   main: string,
@@ -76,7 +75,7 @@ async function compileContractImpl(
 ): Promise<void> {
   // const cmd = `ligo compile-contract ${srcFilePath} ${main} --output=${dstFilePath}`;
   const cmd = `docker run --rm -v $PWD:$PWD -w $PWD ligolang/ligo:0.11.0 compile-contract ${srcFilePath} ${main} --output=${dstFilePath}  && rm -f bisect*.coverage`;
-  await runCmd(cwd, cmd);
+  return runCmd(cwd, cmd);
 }
 
 export async function runCmd(cwd: string, cmd: string): Promise<void> {


### PR DESCRIPTION
This PR does the following:

- Parallelizes calls to the LIGO compiler f709db1.
- Parameterizes the compiler entry point's `main` function with an `LigoEnv` for modularity 355f414.
- Removes extraneous `await` keywords 404a4eb.