### PR TITLE
Generate Contract Types

### DIFF
--- a/packages/minter-contracts/.yarnrc
+++ b/packages/minter-contracts/.yarnrc
@@ -1,0 +1,1 @@
+registry "https://npm.preview.tezostaquito.io/"

--- a/packages/minter-contracts/package.json
+++ b/packages/minter-contracts/package.json
@@ -19,11 +19,12 @@
     "build:watch": "tsc -w -p .",
     "build": "tsc -p tsconfig.build.json",
     "compile-contracts": "ts-node src/compile-contracts.ts; ts-node src/contracts-to-ts.ts",
+    "generate-types": "contract-type-generator --g ./bin ./types",
     "bootstrap": "ts-node src/bootstrap-contracts-config.ts",
     "bootstrap-sandbox": "env TZ_NETWORK=sandbox ts-node src/bootstrap-contracts-config.ts",
     "bootstrap-testnet": "env TZ_NETWORK=testnet ts-node src/bootstrap-contracts-config.ts",
     "bootstrap-mainnet": "env TZ_NETWORK=mainnet ts-node src/bootstrap-contracts-config.ts",
-    "prepare": "yarn compile-contracts && yarn build"
+    "prepare": "yarn compile-contracts && yarn generate-types && yarn build"
   },
   "bin": {
     "compile-contracts": "ts-node src/compile-contracts.ts",
@@ -35,6 +36,7 @@
   "author": "TQ Tezos Maintainers <info@tqtezos.com>",
   "license": "MIT",
   "devDependencies": {
+    "@taquito/contract-type-generator": "8.0.6-beta.0-0bf620b3--722",
     "@taquito/michel-codec": "^8.0.6-beta.0",
     "@types/configstore": "4.0.0",
     "@types/jest": "26.0.10",

--- a/packages/minter-contracts/types/english_auction_tez.ts
+++ b/packages/minter-contracts/types/english_auction_tez.ts
@@ -1,0 +1,59 @@
+
+import { address, BigMap, int, mutez, nat, timestamp } from '@taquito/contract-type-generator';
+
+type Storage = {
+    pauseable_admin?: {
+        admin: address;
+        paused: boolean;
+        pending_admin?: address;
+    };
+    current_id: nat;
+    max_auction_time: nat;
+    max_config_to_start_time: nat;
+    auctions: BigMap<nat, {
+        seller: address;
+        current_bid: mutez;
+        start_time: timestamp;
+        last_bid_time: timestamp;
+        round_time: int;
+        extend_time: int;
+        asset: Array<{
+            fa2_address: address;
+            fa2_batch: Array<{
+                token_id: nat;
+                amount: nat;
+            }>;
+        }>;
+        min_raise_percent: nat;
+        min_raise: mutez;
+        end_time: timestamp;
+        highest_bidder: address;
+    }>;
+};
+
+type Methods = {
+    confirm_admin: () => Promise<void>;
+    pause: (param: boolean) => Promise<void>;
+    set_admin: (param: address) => Promise<void>;
+    bid: (param: nat) => Promise<void>;
+    cancel: (param: nat) => Promise<void>;
+    resolve: (param: nat) => Promise<void>;
+    configure: (params: {
+        opening_price: mutez;
+        min_raise_percent: nat;
+        min_raise: mutez;
+        round_time: nat;
+        extend_time: nat;
+        asset: Array<{
+            fa2_address: address;
+            fa2_batch: Array<{
+                token_id: nat;
+                amount: nat;
+            }>;
+        }>;
+        start_time: timestamp;
+        end_time: timestamp;
+    }) => Promise<void>;
+};
+
+export type Contract = { methods: Methods, storage: Storage, code: { __type: 'EnglishAuctionTezCodeType' } };

--- a/packages/minter-contracts/types/fa2_multi_ft_asset.ts
+++ b/packages/minter-contracts/types/fa2_multi_ft_asset.ts
@@ -1,0 +1,74 @@
+
+import { address, BigMap, bytes, contract, MMap, nat, unit } from '@taquito/contract-type-generator';
+
+type Storage = {
+    admin?: {
+        admin: address;
+        paused: boolean;
+        pending_admin?: address;
+    };
+    assets: {
+        ledger: BigMap<{
+            0: address;
+            1: nat;
+        }, nat>;
+        operators: BigMap<{
+            0: address;
+            1: address;
+            2: nat;
+        }, unit>;
+        token_metadata: BigMap<nat, {
+            token_id: nat;
+            token_info: MMap<string, bytes>;
+        }>;
+        token_total_supply: BigMap<nat, nat>;
+    };
+    metadata: BigMap<string, bytes>;
+};
+
+type Methods = {
+    confirm_admin: () => Promise<void>;
+    pause: (param: boolean) => Promise<void>;
+    set_admin: (param: address) => Promise<void>;
+    balance_of: (params: {
+        requests: Array<{
+            owner: address;
+            token_id: nat;
+        }>;
+        callback: contract;
+    }) => Promise<void>;
+    transfer: (params: {
+        from_: address;
+        txs: Array<{
+            to_: address;
+            token_id: nat;
+            amount: nat;
+        }>;
+    }) => Promise<void>;
+    add_operator: (params: {
+        owner: address;
+        operator: address;
+        token_id: nat;
+    }) => Promise<void>;
+    remove_operator: (params: {
+        owner: address;
+        operator: address;
+        token_id: nat;
+    }) => Promise<void>;
+    burn_tokens: (params: {
+        owner: address;
+        token_id: nat;
+        amount: nat;
+    }) => Promise<void>;
+    create_token: (params: {
+        token_id: nat;
+        token_info: MMap<string, bytes>;
+    }) => Promise<void>;
+    mint_tokens: (params: {
+        owner: address;
+        token_id: nat;
+        amount: nat;
+    }) => Promise<void>;
+};
+
+export type Contract = { methods: Methods, storage: Storage, code: { __type: 'Fa2MultiFtAssetCodeType' } };

--- a/packages/minter-contracts/types/fa2_multi_ft_faucet.ts
+++ b/packages/minter-contracts/types/fa2_multi_ft_faucet.ts
@@ -1,0 +1,66 @@
+
+import { address, BigMap, bytes, contract, MMap, nat, unit } from '@taquito/contract-type-generator';
+
+type Storage = {
+    assets: {
+        ledger: BigMap<{
+            0: address;
+            1: nat;
+        }, nat>;
+        operators: BigMap<{
+            0: address;
+            1: address;
+            2: nat;
+        }, unit>;
+        token_metadata: BigMap<nat, {
+            token_id: nat;
+            token_info: MMap<string, bytes>;
+        }>;
+        token_total_supply: BigMap<nat, nat>;
+    };
+    metadata: BigMap<string, bytes>;
+};
+
+type Methods = {
+    balance_of: (params: {
+        requests: Array<{
+            owner: address;
+            token_id: nat;
+        }>;
+        callback: contract;
+    }) => Promise<void>;
+    transfer: (params: {
+        from_: address;
+        txs: Array<{
+            to_: address;
+            token_id: nat;
+            amount: nat;
+        }>;
+    }) => Promise<void>;
+    add_operator: (params: {
+        owner: address;
+        operator: address;
+        token_id: nat;
+    }) => Promise<void>;
+    remove_operator: (params: {
+        owner: address;
+        operator: address;
+        token_id: nat;
+    }) => Promise<void>;
+    burn_tokens: (params: {
+        owner: address;
+        token_id: nat;
+        amount: nat;
+    }) => Promise<void>;
+    create_token: (params: {
+        token_id: nat;
+        token_info: MMap<string, bytes>;
+    }) => Promise<void>;
+    mint_tokens: (params: {
+        owner: address;
+        token_id: nat;
+        amount: nat;
+    }) => Promise<void>;
+};
+
+export type Contract = { methods: Methods, storage: Storage, code: { __type: 'Fa2MultiFtFaucetCodeType' } };

--- a/packages/minter-contracts/types/fa2_multi_nft_asset.ts
+++ b/packages/minter-contracts/types/fa2_multi_nft_asset.ts
@@ -1,0 +1,64 @@
+
+import { address, BigMap, bytes, contract, MMap, nat, unit } from '@taquito/contract-type-generator';
+
+type Storage = {
+    admin?: {
+        admin: address;
+        paused: boolean;
+        pending_admin?: address;
+    };
+    assets: {
+        ledger: BigMap<nat, address>;
+        next_token_id: nat;
+        operators: BigMap<{
+            0: address;
+            1: address;
+            2: nat;
+        }, unit>;
+        token_metadata: BigMap<nat, {
+            token_id: nat;
+            token_info: MMap<string, bytes>;
+        }>;
+    };
+    metadata: BigMap<string, bytes>;
+};
+
+type Methods = {
+    confirm_admin: () => Promise<void>;
+    pause: (param: boolean) => Promise<void>;
+    set_admin: (param: address) => Promise<void>;
+    balance_of: (params: {
+        requests: Array<{
+            owner: address;
+            token_id: nat;
+        }>;
+        callback: contract;
+    }) => Promise<void>;
+    transfer: (params: {
+        from_: address;
+        txs: Array<{
+            to_: address;
+            token_id: nat;
+            amount: nat;
+        }>;
+    }) => Promise<void>;
+    add_operator: (params: {
+        owner: address;
+        operator: address;
+        token_id: nat;
+    }) => Promise<void>;
+    remove_operator: (params: {
+        owner: address;
+        operator: address;
+        token_id: nat;
+    }) => Promise<void>;
+    mint: (params: {
+        token_metadata: {
+            token_id: nat;
+            token_info: MMap<string, bytes>;
+        };
+        owner: address;
+    }) => Promise<void>;
+};
+
+export type Contract = { methods: Methods, storage: Storage, code: { __type: 'Fa2MultiNftAssetCodeType' } };

--- a/packages/minter-contracts/types/fa2_multi_nft_faucet.ts
+++ b/packages/minter-contracts/types/fa2_multi_nft_faucet.ts
@@ -1,0 +1,56 @@
+
+import { address, BigMap, bytes, contract, MMap, nat, unit } from '@taquito/contract-type-generator';
+
+type Storage = {
+    assets: {
+        ledger: BigMap<nat, address>;
+        next_token_id: nat;
+        operators: BigMap<{
+            0: address;
+            1: address;
+            2: nat;
+        }, unit>;
+        token_metadata: BigMap<nat, {
+            token_id: nat;
+            token_info: MMap<string, bytes>;
+        }>;
+    };
+    metadata: BigMap<string, bytes>;
+};
+
+type Methods = {
+    balance_of: (params: {
+        requests: Array<{
+            owner: address;
+            token_id: nat;
+        }>;
+        callback: contract;
+    }) => Promise<void>;
+    transfer: (params: {
+        from_: address;
+        txs: Array<{
+            to_: address;
+            token_id: nat;
+            amount: nat;
+        }>;
+    }) => Promise<void>;
+    add_operator: (params: {
+        owner: address;
+        operator: address;
+        token_id: nat;
+    }) => Promise<void>;
+    remove_operator: (params: {
+        owner: address;
+        operator: address;
+        token_id: nat;
+    }) => Promise<void>;
+    mint: (params: {
+        token_metadata: {
+            token_id: nat;
+            token_info: MMap<string, bytes>;
+        };
+        owner: address;
+    }) => Promise<void>;
+};
+
+export type Contract = { methods: Methods, storage: Storage, code: { __type: 'Fa2MultiNftFaucetCodeType' } };

--- a/packages/minter-contracts/types/fixed_price_sale_market.ts
+++ b/packages/minter-contracts/types/fixed_price_sale_market.ts
@@ -1,0 +1,54 @@
+
+import { address, BigMap, nat } from '@taquito/contract-type-generator';
+
+type Storage = {
+    admin?: {
+        admin: address;
+        paused: boolean;
+        pending_admin?: address;
+    };
+    sales: BigMap<{
+        sale_seller: address;
+        tokens: {
+            token_for_sale_address: address;
+            token_for_sale_token_id: nat;
+            money_token_address: address;
+            money_token_token_id: nat;
+        };
+    }, nat>;
+};
+
+type Methods = {
+    confirm_admin: () => Promise<void>;
+    pause: (param: boolean) => Promise<void>;
+    set_admin: (param: address) => Promise<void>;
+    buy: (params: {
+        sale_seller: address;
+        tokens: {
+            token_for_sale_address: address;
+            token_for_sale_token_id: nat;
+            money_token_address: address;
+            money_token_token_id: nat;
+        };
+    }) => Promise<void>;
+    cancel: (params: {
+        sale_seller: address;
+        tokens: {
+            token_for_sale_address: address;
+            token_for_sale_token_id: nat;
+            money_token_address: address;
+            money_token_token_id: nat;
+        };
+    }) => Promise<void>;
+    sell: (params: {
+        sale_price: nat;
+        sale_tokens_param: {
+            token_for_sale_address: address;
+            token_for_sale_token_id: nat;
+            money_token_address: address;
+            money_token_token_id: nat;
+        };
+    }) => Promise<void>;
+};
+
+export type Contract = { methods: Methods, storage: Storage, code: { __type: 'FixedPriceSaleMarketCodeType' } };

--- a/packages/minter-contracts/types/fixed_price_sale_market_tez.ts
+++ b/packages/minter-contracts/types/fixed_price_sale_market_tez.ts
@@ -1,0 +1,46 @@
+
+import { address, BigMap, mutez, nat } from '@taquito/contract-type-generator';
+
+type Storage = {
+    admin?: {
+        admin: address;
+        paused: boolean;
+        pending_admin?: address;
+    };
+    sales: BigMap<{
+        sale_seller: address;
+        sale_token: {
+            token_for_sale_address: address;
+            token_for_sale_token_id: nat;
+        };
+    }, mutez>;
+};
+
+type Methods = {
+    confirm_admin: () => Promise<void>;
+    pause: (param: boolean) => Promise<void>;
+    set_admin: (param: address) => Promise<void>;
+    buy: (params: {
+        sale_seller: address;
+        sale_token: {
+            token_for_sale_address: address;
+            token_for_sale_token_id: nat;
+        };
+    }) => Promise<void>;
+    cancel: (params: {
+        sale_seller: address;
+        sale_token: {
+            token_for_sale_address: address;
+            token_for_sale_token_id: nat;
+        };
+    }) => Promise<void>;
+    sell: (params: {
+        sale_price: mutez;
+        sale_token_param_tez: {
+            token_for_sale_address: address;
+            token_for_sale_token_id: nat;
+        };
+    }) => Promise<void>;
+};
+
+export type Contract = { methods: Methods, storage: Storage, code: { __type: 'FixedPriceSaleMarketTezCodeType' } };

--- a/packages/minter-contracts/types/inspector.ts
+++ b/packages/minter-contracts/types/inspector.ts
@@ -1,0 +1,37 @@
+
+import { address, nat, unit } from '@taquito/contract-type-generator';
+
+type Storage = {
+    0: (
+        { empty: unit }
+        | {
+            state: Array<{
+                request: {
+                    owner: address;
+                    token_id: nat;
+                };
+                balance: nat;
+            }>
+        }
+    );
+};
+
+type Methods = {
+    default: () => Promise<void>;
+    query: (params: {
+        fa2: address;
+        requests: Array<{
+            owner: address;
+            token_id: nat;
+        }>;
+    }) => Promise<void>;
+    response: (params: {
+        request: {
+            owner: address;
+            token_id: nat;
+        };
+        balance: nat;
+    }) => Promise<void>;
+};
+
+export type Contract = { methods: Methods, storage: Storage, code: { __type: 'InspectorCodeType' } };

--- a/yarn.lock
+++ b/yarn.lock
@@ -1390,6 +1390,15 @@
   dependencies:
     "@sinonjs/commons" "^1.7.0"
 
+"@taquito/contract-type-generator@8.0.6-beta.0-0bf620b3--722":
+  version "8.0.6-beta.0-0bf620b3--722"
+  resolved "https://npm.preview.tezostaquito.io/@taquito%2fcontract-type-generator/-/contract-type-generator-8.0.6-beta.0-0bf620b3--722.tgz#51f3bf5fc5b2689d0dd2a65d024afd1d5430bfde"
+  integrity sha512-D+ehg+Hb+aXNQQ8m2b+ySXLE7rJlcxv4Ms2pQGWCtjJjsd9ibHI3ROIeXLMn7yZRa2KlCgiTDEki4gDswty1YA==
+  dependencies:
+    "@taquito/michel-codec" "^8.0.6-beta.0-0bf620b3--722"
+    "@taquito/taquito" "^8.0.6-beta.0-0bf620b3--722"
+    bignumber.js "^9.0.1"
+
 "@taquito/http-utils@^8.0.3-beta.0":
   version "8.0.3-beta.0"
   resolved "https://registry.yarnpkg.com/@taquito/http-utils/-/http-utils-8.0.3-beta.0.tgz#aa26b286cb57df52d8eb18d2235302ad4f52e75e"
@@ -1404,6 +1413,13 @@
   dependencies:
     xhr2-cookies "^1.1.0"
 
+"@taquito/http-utils@^8.0.6-beta-RC.0":
+  version "8.0.6-beta-RC.0"
+  resolved "https://npm.preview.tezostaquito.io/@taquito%2fhttp-utils/-/http-utils-8.0.6-beta-RC.0.tgz#3540cc4faace891ebc6d0be0005ed22478997cf8"
+  integrity sha512-CxTCv4Pby2cFemrixb/xDdengFPCinQeVAg2c2mkUxjGSSW16VimBMOyA0V+ZDiJtQ9EX4sfLGUPPnKfrzJEbg==
+  dependencies:
+    xhr2-cookies "^1.1.0"
+
 "@taquito/michel-codec@^8.0.3-beta.0":
   version "8.0.3-beta.0"
   resolved "https://registry.yarnpkg.com/@taquito/michel-codec/-/michel-codec-8.0.3-beta.0.tgz#7b5be2f371885fea01864950648ec37bcae580b4"
@@ -1413,6 +1429,11 @@
   version "8.0.4-beta-RC.0"
   resolved "https://registry.yarnpkg.com/@taquito/michel-codec/-/michel-codec-8.0.4-beta-RC.0.tgz#551e8fbb1b74025ae4ec8aeb45b83b3e59274f3b"
   integrity sha512-HNU4QuOhvnN3w7njvpvfyn4np2XD7KBvnWXkSq3YWwB6+U/JC33JhakLrlkPoXNNDY1pkCUMLtMtuAGG7siIjg==
+
+"@taquito/michel-codec@^8.0.6-beta-RC.0", "@taquito/michel-codec@^8.0.6-beta.0-0bf620b3--722":
+  version "8.0.6-beta-RC.0"
+  resolved "https://npm.preview.tezostaquito.io/@taquito%2fmichel-codec/-/michel-codec-8.0.6-beta-RC.0.tgz#c46ce3496631d2959cf47ba89df56fccaf13ee57"
+  integrity sha512-qZ7U/HfyhpjlEcQu9ivEcGXUUWgqVpzBH9CzvWvQIN8ap27wzFbIEEX8An7CNoskRRxfEytU3P3f+MTNdPgH0w==
 
 "@taquito/michel-codec@^8.0.6-beta.0":
   version "8.0.6-beta.0"
@@ -1439,6 +1460,16 @@
     bignumber.js "^9.0.1"
     fast-json-stable-stringify "^2.1.0"
 
+"@taquito/michelson-encoder@^8.0.6-beta-RC.0":
+  version "8.0.6-beta-RC.0"
+  resolved "https://npm.preview.tezostaquito.io/@taquito%2fmichelson-encoder/-/michelson-encoder-8.0.6-beta-RC.0.tgz#668fcacdeedf4cb8035adb7a964c6cd8b0bc5da6"
+  integrity sha512-2/Ts3ZPtJIsgZXV4vP0P1o7hLjn0lHwwMjdjXDdijyNP+asOsCFLuoxbPzyfCJk3MBJFIvaqL/xrLEZPiBp30A==
+  dependencies:
+    "@taquito/rpc" "^8.0.6-beta-RC.0"
+    "@taquito/utils" "^8.0.6-beta-RC.0"
+    bignumber.js "^9.0.1"
+    fast-json-stable-stringify "^2.1.0"
+
 "@taquito/rpc@8.0.3-beta.0", "@taquito/rpc@^8.0.3-beta.0":
   version "8.0.3-beta.0"
   resolved "https://registry.yarnpkg.com/@taquito/rpc/-/rpc-8.0.3-beta.0.tgz#801d352263d97510fc90897eb0b132d214f235c6"
@@ -1454,6 +1485,15 @@
   integrity sha512-+/4S8CUvCIodJQCIkKb0mr6OmS4/5yD/hGVXUEoYXTwvvatiwRa41zfhPREtCGK79XIcw5aBbZaGiLfUEN1K9A==
   dependencies:
     "@taquito/http-utils" "^8.0.4-beta-RC.0"
+    bignumber.js "^9.0.1"
+    lodash "^4.17.20"
+
+"@taquito/rpc@^8.0.6-beta-RC.0":
+  version "8.0.6-beta-RC.0"
+  resolved "https://npm.preview.tezostaquito.io/@taquito%2frpc/-/rpc-8.0.6-beta-RC.0.tgz#3d23b820072d9b8bd20e26ca144ed83c350fc274"
+  integrity sha512-PI4cTSwFdLFBwSenzrTb7nCY+PnsJDysl1DhCexaTHTN1Smg4eRJq6Dxy+r/leVN0tx/OrOOyrRj6RU9NMNpig==
+  dependencies:
+    "@taquito/http-utils" "^8.0.6-beta-RC.0"
     bignumber.js "^9.0.1"
     lodash "^4.17.20"
 
@@ -1499,6 +1539,20 @@
     rx-sandbox "^1.0.3"
     rxjs "^6.6.3"
 
+"@taquito/taquito@^8.0.6-beta.0-0bf620b3--722":
+  version "8.0.6-beta-RC.0"
+  resolved "https://npm.preview.tezostaquito.io/@taquito%2ftaquito/-/taquito-8.0.6-beta-RC.0.tgz#2bbdfa7ce4a850fba8b7bbd28548d9496fc0af00"
+  integrity sha512-4fHGqSegjq6WzGQpXmWtRNk89UngaM/YXqbrzJAeyUsY1AGqLot/sFPEjpCbkz1vZD3WVijGXpFys9vnYSjIGQ==
+  dependencies:
+    "@taquito/http-utils" "^8.0.6-beta-RC.0"
+    "@taquito/michel-codec" "^8.0.6-beta-RC.0"
+    "@taquito/michelson-encoder" "^8.0.6-beta-RC.0"
+    "@taquito/rpc" "^8.0.6-beta-RC.0"
+    "@taquito/utils" "^8.0.6-beta-RC.0"
+    bignumber.js "^9.0.1"
+    rx-sandbox "^1.0.3"
+    rxjs "^6.6.3"
+
 "@taquito/tzip16@^8.0.4-beta.0":
   version "8.0.4-beta-RC.0"
   resolved "https://registry.yarnpkg.com/@taquito/tzip16/-/tzip16-8.0.4-beta-RC.0.tgz#872f8d12c84a946e7a39f41273167ae9bb817fab"
@@ -1525,6 +1579,15 @@
   version "8.0.4-beta-RC.0"
   resolved "https://registry.yarnpkg.com/@taquito/utils/-/utils-8.0.4-beta-RC.0.tgz#8d582dcdbfb8895bd035e06375f715984cd3d886"
   integrity sha512-ohjjFm22F5B20XgWQGs09Bp7AWLSFznGC7XNdKdCGplLVb+R0IGL/M656HoDQgMAoTNt9azdWWW6TxgG9Mii7Q==
+  dependencies:
+    blakejs "^1.1.0"
+    bs58check "^2.1.2"
+    buffer "^5.6.0"
+
+"@taquito/utils@^8.0.6-beta-RC.0":
+  version "8.0.6-beta-RC.0"
+  resolved "https://npm.preview.tezostaquito.io/@taquito%2futils/-/utils-8.0.6-beta-RC.0.tgz#5d24b6b1b9f823b0b9e478d6a04495acc2c34ebe"
+  integrity sha512-sC7RIQRmGxuxbJOgLVNoo0G6Zh5dTZorHV6vRUOkxs4KWrVmqdpoGMY+1EX6iiVc7fwKptfvyB/b8f3pDJ134w==
   dependencies:
     blakejs "^1.1.0"
     bs58check "^2.1.2"


### PR DESCRIPTION
This replaces #53 

- Generate Contract Types (using the private npm taquito package)
- Add the generator to yarn build (like the compile-contracts script)
- Add code type that matches the compile-contracts output: e.g. `code: { __type: 'EnglishAuctionTezCodeType' }`