### PR TITLE
Move `index.ts` to `bin-ts` folder

### DIFF
--- a/packages/minter-contracts/.gitignore
+++ b/packages/minter-contracts/.gitignore
@@ -2,5 +2,4 @@ jsout
 node_modules
 *.cabal
 .stack-work
-index.ts
 bin-ts/**

--- a/packages/minter-contracts/src/generate-index.ts
+++ b/packages/minter-contracts/src/generate-index.ts
@@ -30,8 +30,8 @@ const generateIndex = (codeFiles: string[]) => {
 
   const codeImports = fileNames
     .map(fileName =>
-      `import { ${fileNameToCodeObject(fileName)} } from './${path.relative(process.cwd(), typesPath)}/${fileName}.code';\n` +
-      `import { ${fileNameToContractType(fileName)} } from './${path.relative(process.cwd(), typesPath)}/${fileName}.types';`
+      `import { ${fileNameToCodeObject(fileName)} } from './${fileName}.code';\n` +
+      `import { ${fileNameToContractType(fileName)} } from './${fileName}.types';`
       ,
     )
     .join('\n');
@@ -49,7 +49,7 @@ try {
     .filter(x => x.endsWith('.code.ts'));
 
   $log.info('Writing index');
-  fs.writeFileSync('index.ts', generateIndex(codeFiles));
+  fs.writeFileSync(`${typesPath}/index.ts`, generateIndex(codeFiles));
   process.exit(0);
 } catch (e) {
   $log.error(e);

--- a/packages/minter-contracts/tsconfig.build.json
+++ b/packages/minter-contracts/tsconfig.build.json
@@ -1,4 +1,4 @@
 {
   "extends": "./tsconfig.json",
-  "include": ["bin-ts", "index.ts"]
+  "include": ["bin-ts"]
 }

--- a/packages/minter-contracts/tsconfig.json
+++ b/packages/minter-contracts/tsconfig.json
@@ -3,5 +3,5 @@
   "compilerOptions": {
     "outDir": "dist"
   },
-  "include": ["src", "test", "bin-ts", "index.ts"],
+  "include": ["src", "test"],
 }


### PR DESCRIPTION
`index.ts` as it exists now is entirely generated. As such it makes sense to collocate it with the other generated files rather than giving it special treatment.

By removing [`index.ts` from the `tsconfig.build.json`'s `include` property](https://github.com/tqtezos/minter-sdk/commit/3a19bb50e6cc8670105e000386d5f279fb99049a#diff-2f710a9dca621f5b82e428e672b59b9e8e86aaab09647b7b9176f68807c610faR3), no modification to `package.json`'s `main` property is necessary, as the index still remains at the root level of `dist` with all generated types positioned adjacently.