### PR TITLE
Property-based tests for the editions contract

### DIFF
--- a/packages/minter-contracts/package.yaml
+++ b/packages/minter-contracts/package.yaml
@@ -41,7 +41,6 @@ tests:
       - containers
       - cleveland
       - fmt
-      - lens
       - lorentz
       - named
       - morley
@@ -51,3 +50,5 @@ tests:
       - sized
       - tasty
       - type-natural
+      - hedgehog
+      - tasty-hedgehog

--- a/packages/minter-contracts/package.yaml
+++ b/packages/minter-contracts/package.yaml
@@ -30,6 +30,7 @@ library:
     - morley
     - morley-prelude
     - morley-ledgers
+    - fmt
 
 tests:
   minter-sdk-tests:

--- a/packages/minter-contracts/src-hs/Lorentz/Contracts/EnglishAuction/Allowlisted.hs
+++ b/packages/minter-contracts/src-hs/Lorentz/Contracts/EnglishAuction/Allowlisted.hs
@@ -52,10 +52,6 @@ instance ParameterHasEntrypoints (AllowlistedEntrypoints Tez.AuctionEntrypoints)
 instance ParameterHasEntrypoints (AllowlistedEntrypoints TezPermit.PermitAuctionEntrypoints) where
   type ParameterEntrypointsDerivation (AllowlistedEntrypoints TezPermit.PermitAuctionEntrypoints) = EpdRecursive
 
--- This empty slice is a workaround, so that all the declarations above and
--- their instances may be in the type environment in the TH splice below.
-$(pure [])
-
 -- Contract
 ----------------------------------------------------------------------------
 

--- a/packages/minter-contracts/src-hs/Lorentz/Contracts/EnglishAuction/FA2.hs
+++ b/packages/minter-contracts/src-hs/Lorentz/Contracts/EnglishAuction/FA2.hs
@@ -134,10 +134,6 @@ deriving anyclass instance HasAnnotation AuctionEntrypoints
 instance ParameterHasEntrypoints AuctionEntrypoints where
   type ParameterEntrypointsDerivation AuctionEntrypoints = EpdRecursive
 
--- This empty slice is a workaround, so that all the declarations above and
--- their instances may be in the type environment in the TH splice below.
-$(pure [])
-
 -- Contract
 ----------------------------------------------------------------------------
 

--- a/packages/minter-contracts/src-hs/Lorentz/Contracts/EnglishAuction/Tez.hs
+++ b/packages/minter-contracts/src-hs/Lorentz/Contracts/EnglishAuction/Tez.hs
@@ -121,10 +121,6 @@ deriving anyclass instance HasAnnotation AuctionEntrypoints
 instance ParameterHasEntrypoints AuctionEntrypoints where
   type ParameterEntrypointsDerivation AuctionEntrypoints = EpdRecursive
 
--- This empty slice is a workaround, so that all the declarations above and
--- their instances may be in the type environment in the TH splice below.
-$(pure [])
-
 -- Contract
 ----------------------------------------------------------------------------
 

--- a/packages/minter-contracts/src-hs/Lorentz/Contracts/EnglishAuction/TezPermit.hs
+++ b/packages/minter-contracts/src-hs/Lorentz/Contracts/EnglishAuction/TezPermit.hs
@@ -57,10 +57,6 @@ deriving anyclass instance HasAnnotation PermitAuctionEntrypoints
 instance ParameterHasEntrypoints PermitAuctionEntrypoints where
   type ParameterEntrypointsDerivation PermitAuctionEntrypoints = EpdRecursive
 
--- This empty slice is a workaround, so that all the declarations above and
--- their instances may be in the type environment in the TH splice below.
-$(pure [])
-
 -- Contract
 ----------------------------------------------------------------------------
 

--- a/packages/minter-contracts/src-hs/Lorentz/Contracts/FA2.hs
+++ b/packages/minter-contracts/src-hs/Lorentz/Contracts/FA2.hs
@@ -1,0 +1,48 @@
+-- | Lorentz bindings for FA2-related types.
+module Lorentz.Contracts.FA2
+  ( OperatorStorage
+  , OperatorKey(..)
+  , TokenMetadata(..)
+  , Parameter(..)
+  ) where
+
+import Fmt (Buildable(..), genericF)
+import Lorentz
+
+import qualified Lorentz.Contracts.Spec.FA2Interface as FA2I
+
+type OperatorStorage = BigMap OperatorKey ()
+
+data OperatorKey = OperatorKey
+  { owner :: Address
+  , operator :: Address
+  , tokenId :: FA2I.TokenId
+  }
+  deriving stock (Show, Eq, Ord)
+customGeneric "OperatorKey" rightComb
+deriving anyclass instance IsoValue OperatorKey
+deriving anyclass instance HasAnnotation OperatorKey
+instance Buildable OperatorKey where build = genericF
+
+-- TODO: add this type to morley-ledgers.
+data TokenMetadata = TokenMetadata
+  { tokenId :: FA2I.TokenId
+  , tokenInfo :: FA2I.TokenMetadata
+  }
+
+customGeneric "TokenMetadata" rightComb
+deriving anyclass instance IsoValue TokenMetadata
+deriving anyclass instance HasAnnotation TokenMetadata
+
+-- | TZIP-12 (and, consequently, @morley-ledgers@) does not prescribe any specific
+-- layout for the FA2 parameter.
+-- So here, we define a data type that uses the same layout we chose for our ligo contracts.
+data Parameter
+  = Balance_of FA2I.BalanceRequestParams
+  | Transfer FA2I.TransferParams
+  | Update_operators FA2I.UpdateOperatorsParam
+  deriving stock (Eq, Show)
+
+customGeneric "Parameter" ligoLayout
+deriving anyclass instance IsoValue Parameter
+deriving anyclass instance HasAnnotation Parameter

--- a/packages/minter-contracts/src-hs/Lorentz/Contracts/Marketplace/Allowlisted.hs
+++ b/packages/minter-contracts/src-hs/Lorentz/Contracts/Marketplace/Allowlisted.hs
@@ -47,10 +47,6 @@ instance ParameterHasEntrypoints (AllowlistedEntrypoints MarketplaceEntrypoints)
 instance ParameterHasEntrypoints (AllowlistedEntrypoints MarketplaceTezEntrypoints) where
   type ParameterEntrypointsDerivation (AllowlistedEntrypoints MarketplaceTezEntrypoints) = EpdRecursive
 
--- This empty slice is a workaround, so that all the declarations above and
--- their instances may be in the type environment in the TH splice below.
-$(pure [])
-
 -- Contract
 ----------------------------------------------------------------------------
 

--- a/packages/minter-contracts/src-hs/Lorentz/Contracts/Marketplace/FA2.hs
+++ b/packages/minter-contracts/src-hs/Lorentz/Contracts/Marketplace/FA2.hs
@@ -66,10 +66,6 @@ deriving anyclass instance HasAnnotation MarketplaceEntrypoints
 instance ParameterHasEntrypoints MarketplaceEntrypoints where
   type ParameterEntrypointsDerivation MarketplaceEntrypoints = EpdRecursive
 
--- This empty slice is a workaround, so that all the declarations above and
--- their instances may be in the type environment in the TH splice below.
-$(pure [])
-
 -- Contract
 ----------------------------------------------------------------------------
 

--- a/packages/minter-contracts/src-hs/Lorentz/Contracts/Marketplace/Tez.hs
+++ b/packages/minter-contracts/src-hs/Lorentz/Contracts/Marketplace/Tez.hs
@@ -64,10 +64,6 @@ deriving anyclass instance HasAnnotation MarketplaceTezEntrypoints
 instance ParameterHasEntrypoints MarketplaceTezEntrypoints where
   type ParameterEntrypointsDerivation MarketplaceTezEntrypoints = EpdRecursive
 
--- This empty slice is a workaround, so that all the declarations above and
--- their instances may be in the type environment in the TH splice below.
-$(pure [])
-
 -- Contract
 ----------------------------------------------------------------------------
 

--- a/packages/minter-contracts/src-hs/Lorentz/Contracts/MinterCollection/Editions.hs
+++ b/packages/minter-contracts/src-hs/Lorentz/Contracts/MinterCollection/Editions.hs
@@ -1,0 +1,86 @@
+-- | Lorentz bindings for the editions contract.
+module Lorentz.Contracts.MinterCollection.Editions
+  ( EditionInfo
+  , EditionId(..)
+  , EditionMetadata(..)
+  , Storage(..)
+  , MintEditionParam(..)
+  , DistributeEditionParam(..)
+  , Entrypoints(..)
+  , editionsContract
+  ) where
+
+import Fmt (Buildable(..), genericF)
+import Lorentz
+import Michelson.Test.Import (embedContractM)
+import qualified Michelson.Typed as T
+
+import qualified Lorentz.Contracts.MinterCollection.Nft.Asset as NftAsset
+import Lorentz.Contracts.MinterSdk (inBinFolder)
+
+type EditionInfo = Map MText ByteString
+
+newtype EditionId = EditionId { unEditionId :: Natural }
+  deriving stock (Generic, Eq, Ord, Show)
+  deriving newtype (IsoValue, HasAnnotation, Num, Buildable)
+
+data EditionMetadata = EditionMetadata
+  { creator :: Address
+  , editionInfo :: EditionInfo
+  , numberOfEditions :: Natural
+  , numberOfEditionsToDistribute :: Natural
+  }
+  deriving stock (Show, Eq)
+customGeneric "EditionMetadata" rightComb
+deriving anyclass instance IsoValue EditionMetadata
+deriving anyclass instance HasAnnotation EditionMetadata
+instance Buildable EditionMetadata where build = genericF
+
+data Storage = Storage
+  { nextEditionId :: EditionId
+  , maxEditionsPerRun :: Natural
+  , editionsMetadata :: BigMap EditionId EditionMetadata
+  , nftAssetStorage :: NftAsset.Storage
+  }
+  deriving stock (Show, Eq)
+customGeneric "Storage" ligoLayout
+deriving anyclass instance IsoValue Storage
+deriving anyclass instance HasAnnotation Storage
+instance Buildable Storage where build = genericF
+
+data MintEditionParam = MintEditionParam
+  { editionInfo :: EditionInfo
+  , numberOfEditions :: Natural
+  }
+  deriving stock (Show, Eq)
+customGeneric "MintEditionParam" ligoLayout
+deriving anyclass instance IsoValue MintEditionParam
+deriving anyclass instance HasAnnotation MintEditionParam
+
+data DistributeEditionParam = DistributeEditionParam
+  { editionId :: EditionId
+  , receivers :: [Address]
+  }
+  deriving stock (Show, Eq)
+customGeneric "DistributeEditionParam" ligoLayout
+deriving anyclass instance IsoValue DistributeEditionParam
+deriving anyclass instance HasAnnotation DistributeEditionParam
+
+data Entrypoints
+  = FA2 NftAsset.Entrypoints
+  | Mint_editions [MintEditionParam]
+  | Distribute_editions [DistributeEditionParam]
+  deriving stock (Show, Eq)
+customGeneric "Entrypoints" ligoLayout
+deriving anyclass instance IsoValue Entrypoints
+deriving anyclass instance HasAnnotation Entrypoints
+
+instance ParameterHasEntrypoints Entrypoints where
+  type ParameterEntrypointsDerivation Entrypoints = EpdRecursive
+
+----------------------------------------------------------------------------
+-- Contract
+----------------------------------------------------------------------------
+
+editionsContract :: T.Contract (ToT Entrypoints) (ToT Storage)
+editionsContract = $$(embedContractM (inBinFolder "fa2_multi_nft_token_editions.tz"))

--- a/packages/minter-contracts/src-hs/Lorentz/Contracts/MinterCollection/Nft/Asset.hs
+++ b/packages/minter-contracts/src-hs/Lorentz/Contracts/MinterCollection/Nft/Asset.hs
@@ -1,0 +1,34 @@
+-- | Lorentz bindings for @minter_collection/nft/fa2_multi_nft_asset.mligo@
+module Lorentz.Contracts.MinterCollection.Nft.Asset
+  ( Entrypoints(..)
+  , Storage(..)
+  ) where
+
+
+import Fmt (Buildable(..), genericF)
+import Lorentz
+
+import qualified Lorentz.Contracts.FA2 as FA2
+import qualified Lorentz.Contracts.MinterCollection.Nft.Token as NftToken
+import qualified Lorentz.Contracts.PausableAdminOption as Admin
+
+data Entrypoints
+  = Assets FA2.Parameter
+  | Admin Admin.AdminEntrypoints
+  deriving stock (Show, Eq)
+customGeneric "Entrypoints" ligoLayout
+deriving anyclass instance IsoValue Entrypoints
+deriving anyclass instance HasAnnotation Entrypoints
+
+-- Note: Hardcoded to use 'PausableAdminOption' (Simple admin),
+-- but should be generalized to work with any admin.
+data Storage = Storage
+  { assets :: NftToken.Storage
+  , admin :: Admin.AdminStorageRecord
+  , metadata :: BigMap MText ByteString
+  }
+  deriving stock (Show, Eq)
+customGeneric "Storage" ligoLayout
+deriving anyclass instance IsoValue Storage
+deriving anyclass instance HasAnnotation Storage
+instance Buildable Storage where build = genericF

--- a/packages/minter-contracts/src-hs/Lorentz/Contracts/MinterCollection/Nft/Token.hs
+++ b/packages/minter-contracts/src-hs/Lorentz/Contracts/MinterCollection/Nft/Token.hs
@@ -1,0 +1,22 @@
+-- | Lorentz bindings for @minter_collection/nft/fa2_multi_nft_token.mligo@
+module Lorentz.Contracts.MinterCollection.Nft.Token
+  ( Storage(..)
+  ) where
+
+
+import Fmt (Buildable(..), genericF)
+import Lorentz
+
+import qualified Lorentz.Contracts.FA2 as FA2
+import qualified Lorentz.Contracts.Spec.FA2Interface as FA2I
+import Util ()
+
+data Storage = Storage
+  { ledger :: BigMap FA2I.TokenId Address
+  , operators :: FA2.OperatorStorage
+  }
+  deriving stock (Show, Eq)
+customGeneric "Storage" ligoLayout
+deriving anyclass instance IsoValue Storage
+deriving anyclass instance HasAnnotation Storage
+instance Buildable Storage where build = genericF

--- a/packages/minter-contracts/src-hs/Lorentz/Contracts/NonPausableSimpleAdmin.hs
+++ b/packages/minter-contracts/src-hs/Lorentz/Contracts/NonPausableSimpleAdmin.hs
@@ -32,10 +32,6 @@ initAdminStorage admin = AdminStorage
   , pendingAdmin = Nothing
   }
 
--- This empty slice is a workaround, so that all the declarations above and
--- their instances may be in the type environment in the TH splice below.
-$(pure [])
-
 -- Errors
 ----------------------------------------------------------------------------
 

--- a/packages/minter-contracts/src-hs/Lorentz/Contracts/PausableAdminOption.hs
+++ b/packages/minter-contracts/src-hs/Lorentz/Contracts/PausableAdminOption.hs
@@ -1,6 +1,7 @@
 -- | Lorentz bindings for the pausable admin contract.
 module Lorentz.Contracts.PausableAdminOption where
 
+import Fmt (Buildable(..), genericF)
 import Lorentz
 
 -- Types
@@ -11,10 +12,12 @@ data AdminStorageRecord = AdminStorage
   , pendingAdmin :: Maybe Address
   , paused :: Bool
   }
+  deriving stock (Show, Eq)
 
 customGeneric "AdminStorageRecord" ligoLayout
 deriving anyclass instance IsoValue AdminStorageRecord
 deriving anyclass instance HasAnnotation AdminStorageRecord
+instance Buildable AdminStorageRecord where build = genericF
 
 type AdminStorage = Maybe AdminStorageRecord
 
@@ -22,6 +25,7 @@ data AdminEntrypoints
   = Set_admin Address
   | Confirm_admin
   | Pause Bool
+  deriving stock (Show, Eq)
 
 customGeneric "AdminEntrypoints" ligoLayout
 deriving anyclass instance IsoValue AdminEntrypoints

--- a/packages/minter-contracts/src-hs/Lorentz/Contracts/PausableAdminOption.hs
+++ b/packages/minter-contracts/src-hs/Lorentz/Contracts/PausableAdminOption.hs
@@ -40,10 +40,6 @@ initAdminStorage admin = Just AdminStorage
 noAdminStorage :: AdminStorage
 noAdminStorage = Nothing
 
--- This empty slice is a workaround, so that all the declarations above and
--- their instances may be in the type environment in the TH splice below.
-$(pure [])
-
 -- Errors
 ----------------------------------------------------------------------------
 

--- a/packages/minter-contracts/src-hs/Lorentz/Contracts/Swaps/Allowlisted.hs
+++ b/packages/minter-contracts/src-hs/Lorentz/Contracts/Swaps/Allowlisted.hs
@@ -44,10 +44,6 @@ deriving anyclass instance HasAnnotation AllowlistedSwapEntrypoints
 instance ParameterHasEntrypoints AllowlistedSwapEntrypoints where
   type ParameterEntrypointsDerivation AllowlistedSwapEntrypoints = EpdDelegate
 
--- This empty slice is a workaround, so that all the declarations above and
--- their instances may be in the type environment in the TH splice below.
-$(pure [])
-
 -- Contract
 ----------------------------------------------------------------------------
 

--- a/packages/minter-contracts/src-hs/Lorentz/Contracts/Swaps/Basic.hs
+++ b/packages/minter-contracts/src-hs/Lorentz/Contracts/Swaps/Basic.hs
@@ -78,10 +78,6 @@ initSwapStorage = SwapStorage
   , swaps = mempty
   }
 
--- This empty slice is a workaround, so that all the declarations above and
--- their instances may be in the type environment in the TH splice below.
-$(pure [])
-
 -- Contract
 ----------------------------------------------------------------------------
 

--- a/packages/minter-contracts/src-hs/Util.hs
+++ b/packages/minter-contracts/src-hs/Util.hs
@@ -1,0 +1,16 @@
+{-# OPTIONS_GHC -Wno-orphans #-}
+
+module Util () where
+
+import Fmt (Buildable(..))
+import Lorentz (toVal)
+
+----------------------------------------------------------------------------
+-- Orphan instances
+----------------------------------------------------------------------------
+
+instance Buildable () where
+  build () = "()"
+
+instance Buildable ByteString where
+  build = build . toVal

--- a/packages/minter-contracts/stack.yaml
+++ b/packages/minter-contracts/stack.yaml
@@ -20,7 +20,7 @@ extra-deps:
 - git:
     https://gitlab.com/morley-framework/morley.git
   commit:
-    121bf833899d3bcdce63daa3c917f575cf3476ea  # master
+    5fe2d892b64ac22aa29b6c2c07d19bd4c475c210  # master
   subdirs:
     - code/morley
     - code/lorentz
@@ -30,12 +30,12 @@ extra-deps:
 - git:
     https://gitlab.com/morley-framework/indigo.git
   commit:
-    a7c93b410683ec6d86dfcda157f6d7ab9eeda778  # master
+    1177ddb1390610c76b8a735c1fda2eacb2cbef6b  # master
   subdirs:
     - .
 
 - git: https://gitlab.com/morley-framework/morley-ledgers.git
-  commit: c6a5b84cf15ed494f0a711ba4f1b646bbc6ef3d7  # master
+  commit: 8e1ec4c161ee9c22e03c74dccb579634ced6165c  # master
   subdirs:
     - code/morley-ledgers
 
@@ -51,7 +51,7 @@ extra-deps:
   commit: c5d61837eb358989b581ed82b1e79158c4823b1b
 
 - hex-text-0.1.0.2@sha256:154df2b81c1dd38b055fa6a90cb6964f60c5cf4a0ba633ea929d8a79af89519a,1301
-- morley-prelude-0.3.0@sha256:9e9473ac14cfa206adf0a3700764c0251de05042f1fe45daf9cb8556079ae663,2085
+- morley-prelude-0.4.0
 - named-0.3.0.1@sha256:2975d50c9c5d88095026ffc1303d2d9be52e5f588a8f8bcb7003a04b79f10a06,2312
 - show-type-0.1.1@sha256:24f681a3481b3f9630e619d816054804ba1bd6cc05b5978ddd2cece8499ff2fa,1154
 - base16-bytestring-1.0.1.0@sha256:33b9d57afa334d06485033e930c6b13fc760baf88fd8f715ae2f9a4b46e19a54

--- a/packages/minter-contracts/stack.yaml.lock
+++ b/packages/minter-contracts/stack.yaml.lock
@@ -7,55 +7,55 @@ packages:
 - completed:
     subdir: code/morley
     name: morley
-    version: 1.13.0
+    version: 1.14.0
     git: https://gitlab.com/morley-framework/morley.git
     pantry-tree:
       size: 9641
-      sha256: d65540c475280e0b74b586f4146b291dde17b389e7bad7c1deef376ec36428d4
-    commit: 121bf833899d3bcdce63daa3c917f575cf3476ea
+      sha256: 721e612078b98eefbf4ccd39705f64238590e3605103cc9ccbb1cfd3eeafc895
+    commit: 5fe2d892b64ac22aa29b6c2c07d19bd4c475c210
   original:
     subdir: code/morley
     git: https://gitlab.com/morley-framework/morley.git
-    commit: 121bf833899d3bcdce63daa3c917f575cf3476ea
+    commit: 5fe2d892b64ac22aa29b6c2c07d19bd4c475c210
 - completed:
     subdir: code/lorentz
     name: lorentz
-    version: 0.10.0
+    version: 0.11.0
     git: https://gitlab.com/morley-framework/morley.git
     pantry-tree:
-      size: 3741
-      sha256: fce541c1b843a238687baac6bef5db7c729a346dae1d2ee33195e56c8320a7d0
-    commit: 121bf833899d3bcdce63daa3c917f575cf3476ea
+      size: 3872
+      sha256: aa52570569e2d1357ac16984eb0621a1ed64ce6bb72b6a84c6482d3556e01449
+    commit: 5fe2d892b64ac22aa29b6c2c07d19bd4c475c210
   original:
     subdir: code/lorentz
     git: https://gitlab.com/morley-framework/morley.git
-    commit: 121bf833899d3bcdce63daa3c917f575cf3476ea
+    commit: 5fe2d892b64ac22aa29b6c2c07d19bd4c475c210
 - completed:
     subdir: code/cleveland
     name: cleveland
     version: 0.1.0
     git: https://gitlab.com/morley-framework/morley.git
     pantry-tree:
-      size: 12580
-      sha256: d90866ecfa4dded096277532e41da2e4e765ca98aa35abf8d6774d5d1b371d40
-    commit: 121bf833899d3bcdce63daa3c917f575cf3476ea
+      size: 13030
+      sha256: 8ae2de78151c5a70c4f40fe8b9688c8294fed89e30276bebaaf6003068087987
+    commit: 5fe2d892b64ac22aa29b6c2c07d19bd4c475c210
   original:
     subdir: code/cleveland
     git: https://gitlab.com/morley-framework/morley.git
-    commit: 121bf833899d3bcdce63daa3c917f575cf3476ea
+    commit: 5fe2d892b64ac22aa29b6c2c07d19bd4c475c210
 - completed:
     subdir: code/morley-client
     name: morley-client
     version: 0.1.0
     git: https://gitlab.com/morley-framework/morley.git
     pantry-tree:
-      size: 3175
-      sha256: 00f60cb7810aeb4eb22011cac7da5b3c015ce4a106a6cdd9273593e65fe51d28
-    commit: 121bf833899d3bcdce63daa3c917f575cf3476ea
+      size: 3312
+      sha256: c6c5b50629ae8eefda0913141ee5c6225f753e578a5f8e659cb0cc4db38d21c7
+    commit: 5fe2d892b64ac22aa29b6c2c07d19bd4c475c210
   original:
     subdir: code/morley-client
     git: https://gitlab.com/morley-framework/morley.git
-    commit: 121bf833899d3bcdce63daa3c917f575cf3476ea
+    commit: 5fe2d892b64ac22aa29b6c2c07d19bd4c475c210
 - completed:
     subdir: .
     name: indigo
@@ -63,12 +63,12 @@ packages:
     git: https://gitlab.com/morley-framework/indigo.git
     pantry-tree:
       size: 14289
-      sha256: 1a929a186ac8ed7d0552ad45af487b8d710075570f6020263ae8657d5bfa3465
-    commit: a7c93b410683ec6d86dfcda157f6d7ab9eeda778
+      sha256: ef99aad2d1e78d11dbfec854ed368624367efa8edbb9ca13c0f7e9b7c3e53271
+    commit: 1177ddb1390610c76b8a735c1fda2eacb2cbef6b
   original:
     subdir: .
     git: https://gitlab.com/morley-framework/indigo.git
-    commit: a7c93b410683ec6d86dfcda157f6d7ab9eeda778
+    commit: 1177ddb1390610c76b8a735c1fda2eacb2cbef6b
 - completed:
     subdir: code/morley-ledgers
     name: morley-ledgers
@@ -76,12 +76,12 @@ packages:
     git: https://gitlab.com/morley-framework/morley-ledgers.git
     pantry-tree:
       size: 1524
-      sha256: fa2bbd245683f8830182c2cdbe8b44cd5a11ffb60ebacebda4579eb043626118
-    commit: c6a5b84cf15ed494f0a711ba4f1b646bbc6ef3d7
+      sha256: 954ab3e15182915ba802def3b81ac5607adca5e5b33054942e4434cbdf1e1a53
+    commit: 8e1ec4c161ee9c22e03c74dccb579634ced6165c
   original:
     subdir: code/morley-ledgers
     git: https://gitlab.com/morley-framework/morley-ledgers.git
-    commit: c6a5b84cf15ed494f0a711ba4f1b646bbc6ef3d7
+    commit: 8e1ec4c161ee9c22e03c74dccb579634ced6165c
 - completed:
     name: base-noprelude
     version: 4.14.1.0
@@ -145,12 +145,12 @@ packages:
   original:
     hackage: hex-text-0.1.0.2@sha256:154df2b81c1dd38b055fa6a90cb6964f60c5cf4a0ba633ea929d8a79af89519a,1301
 - completed:
-    hackage: morley-prelude-0.3.0@sha256:9e9473ac14cfa206adf0a3700764c0251de05042f1fe45daf9cb8556079ae663,2085
+    hackage: morley-prelude-0.4.0@sha256:7234db1acac9a5554d01bdbf22d63b598c69b9fefaeace0fb6f765bf7bf738d4,2176
     pantry-tree:
-      size: 270
-      sha256: 402cd467a690373ca891fa31650376312be351244c6d7e187ca9961d3708de0a
+      size: 269
+      sha256: 5ef63d068139d79b4bd5832822447ee0a9313da368c70245a79b13e1bc44a2dd
   original:
-    hackage: morley-prelude-0.3.0@sha256:9e9473ac14cfa206adf0a3700764c0251de05042f1fe45daf9cb8556079ae663,2085
+    hackage: morley-prelude-0.4.0
 - completed:
     hackage: named-0.3.0.1@sha256:2975d50c9c5d88095026ffc1303d2d9be52e5f588a8f8bcb7003a04b79f10a06,2312
     pantry-tree:

--- a/packages/minter-contracts/test-hs/Test/Allowlisted.hs
+++ b/packages/minter-contracts/test-hs/Test/Allowlisted.hs
@@ -38,16 +38,16 @@ allowlistUpdateAuthorizationChecks originateFromAdminFn =
   [ nettestScenarioCaps "Can be updated by admin" $ do
       (contract, swapAdmin) <- originateWithAdmin originateFromAdminFn
 
-      withSender (AddressResolved swapAdmin) $
+      withSender swapAdmin $
         call contract (Call @"Update_allowed") mempty
 
   , nettestScenarioCaps "Cannot be updated by non-admins" $ do
       (contract, _swapAdmin) <- originateWithAdmin originateFromAdminFn
       user <- newAddress "user"
 
-      withSender (AddressResolved user) $
+      withSender user $
         call contract (Call @"Update_allowed") mempty
-        & expectError errNotAdmin
+        & expectError contract errNotAdmin
   ]
 
 -- | Single type of allowlist restriction, usually corresponds to one error.
@@ -98,7 +98,7 @@ allowlistChecks AllowlistChecksSetup{..} =
       case allowlistRestrictionsCases of
         AllowlistRestrictionCase{..} :| _ ->
           allowlistRunRestrictedAction setup contract fa2
-            & expectError allowlistError
+            & expectError contract allowlistError
 
   , nettestScenarioCaps "Only FA2s that has been allowed work" $ do
       fa2Setup <- doFA2Setup
@@ -106,14 +106,14 @@ allowlistChecks AllowlistChecksSetup{..} =
       fa2_1 <- originateFA2 "fa2-1" fa2Setup [contract]
       fa2_2 <- originateFA2 "fa2-2" fa2Setup [contract]
 
-      withSender (AddressResolved admin) $
+      withSender admin $
         call contract (Call @"Update_allowed") $ mkFullAllowlist setup [fa2_2]
 
       comment "Check that not yet allowed FA2 does not work"
       case allowlistRestrictionsCases of
         AllowlistRestrictionCase{..} :| _ -> do
           allowlistRunRestrictedAction setup contract fa2_1
-            & expectError allowlistError
+            & expectError contract allowlistError
 
       comment "Allowed FA2 works"
       for_ allowlistRestrictionsCases $ \AllowlistRestrictionCase{..} ->
@@ -125,14 +125,14 @@ allowlistChecks AllowlistChecksSetup{..} =
       fa2 <- originateFA2 "fa2" fa2Setup [contract]
       fa2_another <- originateFA2 "fa2" fa2Setup [contract]
 
-      withSender (AddressResolved admin) $
+      withSender admin $
         call contract (Call @"Update_allowed") $ mkFullAllowlist setup [fa2]
-      withSender (AddressResolved admin) $
+      withSender admin $
         call contract (Call @"Update_allowed") $ mkFullAllowlist setup [fa2_another]
 
       case allowlistRestrictionsCases of
         AllowlistRestrictionCase{..} :| _ -> do
           allowlistRunRestrictedAction setup contract fa2
-            & expectError allowlistError
+            & expectError contract allowlistError
 
   ]

--- a/packages/minter-contracts/test-hs/Test/EnglishAuction/AllowlistedFA2.hs
+++ b/packages/minter-contracts/test-hs/Test/EnglishAuction/AllowlistedFA2.hs
@@ -51,7 +51,7 @@ test_AllowlistChecks = allowlistChecks
         { allowlistError = assetAddressNotAllowed
         , allowlistRunRestrictedAction = \(admin, tokenId) contract fa2 -> do
             now <- getNow
-            withSender (AddressResolved admin) $
+            withSender admin $
               call contract (Call @"Configure") $ (defConfigureParam :: ConfigureParam)
                 { asset = [Tokens (toAddress fa2) [FA2Token tokenId 1]]
                 , startTime = now
@@ -74,22 +74,22 @@ test_Integrational = testGroup "Integrational"
         (BidCurrency (toAddress bidFA2) tokenId) alice
       fa2 <- originateFA2 "fa2" setup [auction]
 
-      withSender (AddressResolved bob) $
+      withSender bob $
         call bidFA2 (Call @"Update_operators") $ one $ AddOperator OperatorParam
           { opOwner = bob
           , opOperator = toAddress auction
           , opTokenId = tokenId
           }
-      withSender (AddressResolved alice) $
+      withSender alice $
         call auction (Call @"Update_allowed") (mkAllowlistParam [fa2])
 
       now <- getNow
 
-      withSender (AddressResolved alice) $
+      withSender alice $
         call auction (Call @"Configure") (defConfigureParam :: ConfigureParam)
           { startTime = now }
 
-      withSender (AddressResolved bob) $
+      withSender bob $
         call auction (Call @"Bid") (BidParam (AuctionId 0) 3)
 
   ]

--- a/packages/minter-contracts/test-hs/Test/EnglishAuction/AllowlistedTez.hs
+++ b/packages/minter-contracts/test-hs/Test/EnglishAuction/AllowlistedTez.hs
@@ -41,7 +41,7 @@ test_AllowlistChecks = allowlistChecks
         { allowlistError = assetAddressNotAllowed
         , allowlistRunRestrictedAction = \(alice, tokenId) contract fa2 -> do
             now <- getNow
-            withSender (AddressResolved alice) $
+            withSender alice $
               call contract (Call @"Configure") $ (defConfigureParam :: ConfigureParam)
                 { asset = [Tokens (toAddress fa2) [FA2Token tokenId 1]]
                 , startTime = now
@@ -62,18 +62,18 @@ test_Integrational = testGroup "Integrational"
       auction <- originateAuctionTezAllowlisted alice
       fa2 <- originateFA2 "fa2" setup [auction]
 
-      withSender (AddressResolved alice) $
+      withSender alice $
         call auction (Call @"Update_allowed") (mkAllowlistParam [fa2])
 
       now <- getNow
 
-      withSender (AddressResolved alice) $
+      withSender alice $
         call auction (Call @"Configure") (defConfigureParam :: ConfigureParam)
           { startTime = now }
 
-      withSender (AddressResolved bob) $
+      withSender bob $
         transfer TransferData
-          { tdTo = addressResolved auction
+          { tdTo = auction
           , tdAmount = toMutez 3
           , tdEntrypoint = ep "bid"
           , tdParameter = AuctionId 0

--- a/packages/minter-contracts/test-hs/Test/EnglishAuction/AllowlistedTezPermit.hs
+++ b/packages/minter-contracts/test-hs/Test/EnglishAuction/AllowlistedTezPermit.hs
@@ -42,7 +42,7 @@ test_AllowlistChecks = allowlistChecks
         { allowlistError = assetAddressNotAllowed
         , allowlistRunRestrictedAction = \(admin, tokenId) contract fa2 -> do
             now <- getNow
-            withSender (AddressResolved admin) $
+            withSender admin $
               call contract (Call @"Permit_configure") $ one $
                 PermitConfigParam
                 { config = defConfigureParam
@@ -68,21 +68,21 @@ test_Integrational = testGroup "Integrational"
       auction <- originateAuctionTezPermitAllowlisted alice
       fa2 <- originateFA2 "fa2" setup [auction]
 
-      withSender (AddressResolved alice) $
+      withSender alice $
         call auction (Call @"Update_allowed") (mkAllowlistParam [fa2])
 
       now <- getNow
 
-      withSender (AddressResolved alice) $
+      withSender alice $
         call auction (Call @"Permit_configure") $ one PermitConfigParam
           { config = (defConfigureParam :: ConfigureParam)
               { startTime = now }
           , optionalPermit = Nothing
           }
 
-      withSender (AddressResolved bob) $
+      withSender bob $
         transfer TransferData
-          { tdTo = addressResolved auction
+          { tdTo = auction
           , tdAmount = toMutez 3
           , tdEntrypoint = ep "bid"
           , tdParameter = AuctionId 0

--- a/packages/minter-contracts/test-hs/Test/Marketplace/AllowlistedFA2.hs
+++ b/packages/minter-contracts/test-hs/Test/Marketplace/AllowlistedFA2.hs
@@ -38,7 +38,7 @@ test_AllowlistChecks = allowlistChecks
       [ AllowlistRestrictionCase
         { allowlistError = saleAddressNotAllowed
         , allowlistRunRestrictedAction = \(alice, tokenId, allowedFA2) market fa2 ->
-            withSender (AddressResolved alice) $
+            withSender alice $
               call market (Call @"Sell") InitSaleParam
                 { salePrice = 1
                 , saleTokensParam = SaleTokenParam
@@ -53,7 +53,7 @@ test_AllowlistChecks = allowlistChecks
       , AllowlistRestrictionCase
         { allowlistError = moneyAddressNotAllowed
         , allowlistRunRestrictedAction = \(alice, tokenId, allowedFA2) market fa2 ->
-            withSender (AddressResolved alice) $
+            withSender alice $
               call market (Call @"Sell") InitSaleParam
                 { salePrice = 1
                 , saleTokensParam = SaleTokenParam
@@ -79,7 +79,7 @@ test_Integrational = testGroup "Integrational"
       market <- originateMarketplaceAllowlisted alice
       fa2 <- originateFA2 "fa2" setup [market]
 
-      withSender (AddressResolved alice) $
+      withSender alice $
         call market (Call @"Update_allowed") (mkAllowlistParam [fa2])
 
       let saleTokensParam = SaleTokenParam
@@ -95,12 +95,12 @@ test_Integrational = testGroup "Integrational"
         , (bob, tokenId1) -: 1
         , (bob, tokenId2) -: -10
         ] $ do
-          withSender (AddressResolved alice) $
+          withSender alice $
             call market (Call @"Sell") InitSaleParam
               { salePrice = 10
               , saleTokensParam
               }
-          withSender (AddressResolved bob) $
+          withSender bob $
             call market (Call @"Buy") SaleParam
               { saleSeller = alice
               , tokens = saleTokensParam

--- a/packages/minter-contracts/test-hs/Test/Marketplace/AllowlistedTez.hs
+++ b/packages/minter-contracts/test-hs/Test/Marketplace/AllowlistedTez.hs
@@ -37,7 +37,7 @@ test_AllowlistChecks = allowlistChecks
       [ AllowlistRestrictionCase
         { allowlistError = saleAddressNotAllowed
         , allowlistRunRestrictedAction = \(alice, tokenId) contract fa2 ->
-            withSender (AddressResolved alice) $
+            withSender alice $
               call contract (Call @"Sell") InitSaleParamTez
                 { salePrice = toMutez 1
                 , saleTokensParam = SaleTokenParamTez (toAddress fa2) tokenId
@@ -58,7 +58,7 @@ test_Integrational = testGroup "Integrational"
       market <- originateMarketplaceTezAllowlisted alice
       fa2 <- originateFA2 "fa2" setup [market]
 
-      withSender (AddressResolved alice) $
+      withSender alice $
         call market (Call @"Update_allowed") (mkAllowlistParam [fa2])
 
       let saleTokensParam = SaleTokenParamTez
@@ -70,15 +70,15 @@ test_Integrational = testGroup "Integrational"
         [ (alice, tokenId1) -: -1
         , (bob, tokenId1) -: 1
         ] $ do
-          withSender (AddressResolved alice) $
+          withSender alice $
             call market (Call @"Sell") InitSaleParamTez
               { salePrice = toMutez 1
               , saleTokensParam = saleTokensParam
               }
 
-          withSender (AddressResolved bob) $
+          withSender bob $
             transfer TransferData
-              { tdTo = addressResolved market
+              { tdTo = market
               , tdAmount = toMutez 1
               , tdEntrypoint = ep "buy"
               , tdParameter = SaleParamTez

--- a/packages/minter-contracts/test-hs/Test/MinterCollection/Editions.hs
+++ b/packages/minter-contracts/test-hs/Test/MinterCollection/Editions.hs
@@ -1,0 +1,311 @@
+module Test.MinterCollection.Editions
+  where
+
+import qualified Data.Map as Map
+import Hedgehog (Gen, Property, forAll, property)
+import qualified Hedgehog.Gen as Gen
+import qualified Hedgehog.Gen.Michelson as Gen
+import qualified Hedgehog.Range as Range
+import Morley.Nettest
+
+import Lorentz
+import Lorentz.Test (contractConsumer)
+import Michelson.Typed (convertContract, untypeValue)
+import qualified Unsafe
+
+import Lorentz.Contracts.MinterCollection.Editions
+import qualified Lorentz.Contracts.MinterCollection.Nft.Asset as NftAsset
+import qualified Lorentz.Contracts.MinterCollection.Nft.Token as NftToken
+import qualified Lorentz.Contracts.PausableAdminOption as Admin
+import Lorentz.Contracts.Spec.FA2Interface (TokenId(..), mkFA2View)
+import qualified Lorentz.Contracts.Spec.FA2Interface as FA2
+import Test.Util (clevelandProp)
+
+hprop_MintEditions_creates_one_entry_for_each_param :: Property
+hprop_MintEditions_creates_one_entry_for_each_param =
+  property $ do
+    editionRuns <- forAll genEditionRunDataList
+    clevelandProp $ do
+      (initialStorage, admin) <- mkStorage $ adjustMaxEditionsPerRun editionRuns
+      editions <- originateEditionsContract initialStorage
+
+      withSender admin $ do
+        mintEditionRuns editions editionRuns
+
+        let expectedEditionsMetadata =
+              BigMap . Map.fromList $ editionRuns <&> \editionRun ->
+                ( dataEditionId editionRun
+                , EditionMetadata
+                    { creator = admin
+                    , editionInfo = dataEditionInfo editionRun
+                    , numberOfEditions = dataNumberOfEditions editionRun
+                    , numberOfEditionsToDistribute = dataNumberOfEditions editionRun
+                    }
+                )
+
+        st <- fromVal @Storage <$> getStorage' editions
+        editionsMetadata st @== expectedEditionsMetadata
+
+hprop_NextEditionId_is_incremented_by_the_number_of_edition_runs_minted :: Property
+hprop_NextEditionId_is_incremented_by_the_number_of_edition_runs_minted =
+  property $ do
+    editionRuns <- forAll genEditionRunDataList
+    clevelandProp $ do
+      (initialStorage, admin) <- mkStorage $ adjustMaxEditionsPerRun editionRuns
+      editions <- originateEditionsContract initialStorage
+
+      withSender admin $ do
+        mintEditionRuns editions editionRuns
+
+        st <- fromVal @Storage <$> getStorage' editions
+        nextEditionId st @== genericLength editionRuns
+
+hprop_Each_distribution_mints_a_new_TokenId :: Property
+hprop_Each_distribution_mints_a_new_TokenId =
+  property $ do
+    editionRuns <- forAll genEditionRunDataList
+    clevelandProp $ do
+      (initialStorage, admin) <- mkStorage $ adjustMaxEditionsPerRun editionRuns
+      editions <- originateEditionsContract initialStorage
+      receivers <- forM editionRuns createReceivers
+      consumer <- originateSimple "balance-response-consumer" [] (contractConsumer @[FA2.BalanceResponseItem])
+
+      withSender admin $ do
+        mintEditionRuns editions editionRuns
+
+        forM_ (editionRuns `zip` receivers) \(editionRun, rcvs) ->
+          forM_ rcvs \rcv -> do
+            -- Check how many editions are still available.
+            st <- fromVal @Storage <$> getStorage' editions
+            let toDistribute =
+                  st
+                    & getEditionMetadata (dataEditionId editionRun)
+                    <&> numberOfEditionsToDistribute
+                    & Unsafe.fromJust
+
+            distributeEditions editions [editionRun] [[rcv]]
+
+            -- According to the spec:
+            -- > Each distribution mints a new token to a token_id equal to
+            -- > edition_id * max_editions_per_run + (number_of_editions - number_of_editions_to_distribute)
+            let expectedTokenId =
+                  unEditionId (dataEditionId editionRun)
+                  * maxEditionsPerRun st
+                  + (dataNumberOfEditions editionRun - toDistribute)
+
+            -- Check that a new FA2 Token ID was minted.
+            let balanceRequest = FA2.BalanceRequestItem rcv (TokenId expectedTokenId)
+            call editions (Call @"Balance_of") (mkFA2View [balanceRequest] consumer)
+            consumerStorage <- fromVal @[[FA2.BalanceResponseItem]] <$> getStorage consumer
+            safeHead consumerStorage @== Just [FA2.BalanceResponseItem balanceRequest 1]
+
+hprop_Distributing_n_editions_decrements_NumberOfEditionsToDistribute_by_n :: Property
+hprop_Distributing_n_editions_decrements_NumberOfEditionsToDistribute_by_n =
+  property $ do
+    editionRuns <- forAll genEditionRunDataList
+    clevelandProp $ do
+      (initialStorage, admin) <- mkStorage $ adjustMaxEditionsPerRun editionRuns
+      editions <- originateEditionsContract initialStorage
+      receivers <- forM editionRuns createReceivers
+
+      withSender admin $ do
+        mintEditionRuns editions editionRuns
+        distributeEditions editions editionRuns receivers
+
+        st <- fromVal @Storage <$> getStorage' editions
+        forM_ editionRuns \er ->
+          (st & getEditionMetadata (dataEditionId er) <&> numberOfEditionsToDistribute)
+            @== Just (dataNumberOfEditions er - dataNumberToDistribute er)
+
+hprop_Distributing_more_editions_than_are_available_fails :: Property
+hprop_Distributing_more_editions_than_are_available_fails =
+  property $ do
+    editionRuns <- forAll $ do
+      editionRunCount <- Gen.int (Range.linear 0 10)
+      -- Edition IDs are sequential, starting at 0
+      forM [0.. editionRunCount - 1] \editionId -> do
+        numberOfEditions <- Gen.integral (Range.linear 0 30)
+        toDistribute <- Gen.integral (Range.linear (numberOfEditions + 1) 100)
+        pure $ EditionRunData (fromIntegral editionId) mempty numberOfEditions toDistribute
+
+    clevelandProp $ do
+      (initialStorage, admin) <- mkStorage $ adjustMaxEditionsPerRun editionRuns
+      editions <- originateEditionsContract initialStorage
+      receivers <- forM editionRuns createReceivers
+
+      withSender admin $ do
+        mintEditionRuns editions editionRuns
+
+        forM_ (editionRuns `zip` receivers) \(editionRun, rcvs) ->
+          distributeEditions editions [editionRun] [rcvs]
+            `expectFailure` failedWith editions [mt|NO_EDITIONS_TO_DISTRIBUTE|]
+
+hprop_Calling_MintEditions_many_times_is_the_same_as_calling_it_once :: Property
+hprop_Calling_MintEditions_many_times_is_the_same_as_calling_it_once =
+  property $ do
+    editionRuns <- forAll genEditionRunDataList
+    clevelandProp $ do
+      (initialStorage, admin) <- mkStorage $ adjustMaxEditionsPerRun editionRuns
+
+      -- Create two contracts, with the same initial storage. Then:
+      --   * Using the first contract, mint all editions at once, in one call
+      --   * Using the second contract, mint all editions, one at a time
+      -- Then check that their storages are equal.
+      editions1 <- originateEditionsContract initialStorage
+      editions2 <- originateEditionsContract initialStorage
+
+      withSender admin $ do
+        -- Mint all editions in one single call
+        mintEditionRuns editions1 editionRuns
+
+        -- Mint all editions, one by one
+        forM_ editionRuns \editionRun ->
+          mintEditionRuns editions2 [editionRun]
+
+        st1 <- fromVal @Storage <$> getStorage' editions1
+        st2 <- fromVal @Storage <$> getStorage' editions2
+
+        st1 @== st2
+
+hprop_Calling_DistributeEditions_many_times_is_the_same_as_calling_it_once :: Property
+hprop_Calling_DistributeEditions_many_times_is_the_same_as_calling_it_once =
+  property $ do
+    editionRuns <- forAll genEditionRunDataList
+    clevelandProp $ do
+      (initialStorage, admin) <- mkStorage $ adjustMaxEditionsPerRun editionRuns
+      receivers <- forM editionRuns createReceivers
+
+      -- Create two contracts, with the same initial storage. Then:
+      --   * Using the first contract, distribute all editions at once, in one call
+      --   * Using the second contract, distribute all editions, one at a time
+      -- Then check that their storages are equal.
+      editions1 <- originateEditionsContract initialStorage
+      editions2 <- originateEditionsContract initialStorage
+
+      withSender admin $ do
+        mintEditionRuns editions1 editionRuns
+        mintEditionRuns editions2 editionRuns
+
+        -- Distribute all editions in one single call
+        distributeEditions editions1 editionRuns receivers
+
+        -- Distribute all editions, one by one
+        forM_ (editionRuns `zip` receivers) \(editionRun, rcvs) ->
+          forM rcvs \rcv ->
+            distributeEditions editions2 [editionRun] [[rcv]]
+
+        st1 <- fromVal @Storage <$> getStorage' editions1
+        st2 <- fromVal @Storage <$> getStorage' editions2
+
+        st1 @== st2
+
+----------------------------------------------------------------------------
+-- Helpers
+----------------------------------------------------------------------------
+
+originateEditionsContract :: MonadNettest caps base m => Storage -> m (TAddress Entrypoints)
+originateEditionsContract storage =
+  TAddress @Entrypoints <$> originateUntypedSimple "editions"
+    (untypeValue $ toVal storage)
+    (convertContract editionsContract)
+
+mintEditionRuns :: (HasCallStack, MonadNettest caps base m) => TAddress Entrypoints -> [EditionRunData] -> m ()
+mintEditionRuns addr editionRuns =
+  call addr (Call @"Mint_editions") $
+    editionRuns <&> \editionRun ->
+      MintEditionParam
+        { editionInfo = dataEditionInfo editionRun
+        , numberOfEditions = dataNumberOfEditions editionRun
+        }
+
+distributeEditions :: (HasCallStack, MonadNettest caps base m) => TAddress Entrypoints -> [EditionRunData] -> [[Address]] -> m ()
+distributeEditions addr editionRuns receivers =
+  call addr (Call @"Distribute_editions") $
+    (editionRuns `zip` receivers) <&> \(editionRun, rcvs) ->
+      DistributeEditionParam
+        { editionId = dataEditionId editionRun
+        , receivers = rcvs
+        }
+
+-- | Generate a list of accounts to distribute editions to.
+createReceivers :: MonadNettest caps base m => EditionRunData -> m [Address]
+createReceivers editionRun = do
+  forM [1 .. dataNumberToDistribute editionRun] \i ->
+    newAddress ("editions-receiver-" <> show i)
+
+-- | Create the contract's storage and an admin account.
+mkStorage :: MonadNettest caps base m => (Storage -> Storage) -> m (Storage, Address)
+mkStorage modifyStorage = do
+  admin <- newAddress "editions-admin"
+  let defaultStorage =
+        Storage
+          { nextEditionId = 0
+          , maxEditionsPerRun = 0
+          , editionsMetadata = mempty
+          , nftAssetStorage = NftAsset.Storage
+              { assets = NftToken.Storage
+                  { ledger = mempty
+                  , operators = mempty
+                  }
+              , admin = Admin.AdminStorage
+                  { admin = admin
+                  , pendingAdmin = Nothing
+                  , paused = False
+                  }
+              , metadata = mempty
+              }
+          }
+  pure (modifyStorage defaultStorage, admin)
+
+-- | Given a list of edition runs to be minted,
+-- sets the storage's `max_editions_per_run` to the correct limit.
+adjustMaxEditionsPerRun :: [EditionRunData] -> Storage -> Storage
+adjustMaxEditionsPerRun editionRuns st =
+  st
+    { maxEditionsPerRun =
+        if null editionRuns
+          then 0
+          else maximum (dataNumberOfEditions <$> editionRuns)
+    }
+
+getEditionMetadata :: EditionId -> Storage -> Maybe EditionMetadata
+getEditionMetadata editionId st =
+  st
+    & editionsMetadata
+    & unBigMap
+    & Map.lookup editionId
+
+----------------------------------------------------------------------------
+-- Generators
+----------------------------------------------------------------------------
+
+-- The data we need to mint an Edition Run and distribute editions.
+data EditionRunData = EditionRunData
+  { dataEditionId :: EditionId
+  , dataEditionInfo :: EditionInfo
+  , dataNumberOfEditions :: Natural -- ^ How many editions exist in this edition run
+  , dataNumberToDistribute :: Natural -- ^ How many editions we will be giving out
+  }
+  deriving stock (Show)
+
+genEditionRunData :: EditionId -> Gen EditionRunData
+genEditionRunData editionId = do
+  editionInfo <- genEditionInfo
+  numberOfEditions <- Gen.integral (Range.linear 0 30)
+  toDistribute <- Gen.integral (Range.linear 0 numberOfEditions)
+  pure $ EditionRunData editionId editionInfo numberOfEditions toDistribute
+
+genEditionRunDataList :: Gen [EditionRunData]
+genEditionRunDataList = do
+  editionRunCount <- Gen.int (Range.linear 0 10)
+
+  -- Edition IDs are sequential, starting at 0
+  forM [0.. editionRunCount - 1] \editionId ->
+    genEditionRunData (fromIntegral editionId)
+
+genEditionInfo :: Gen EditionInfo
+genEditionInfo =
+  Gen.map (Range.linear 0 10) (liftA2 (,) genKeys genValues)
+  where
+    genKeys = Gen.genMText
+    genValues = Gen.bytes (Range.linear 0 10)

--- a/packages/minter-contracts/test-hs/Test/NonPausableSimpleAdmin.hs
+++ b/packages/minter-contracts/test-hs/Test/NonPausableSimpleAdmin.hs
@@ -33,27 +33,27 @@ adminOwnershipTransferChecks originateFn = testGroup "Admin functionality"
       successor <- newAddress "successor"
       contract <- originateFn admin
       call contract (Call @"Set_admin") successor
-        & withSender (AddressResolved admin)
+        & withSender admin
       call contract (Call @"Confirm_admin") ()
-        & withSender (AddressResolved successor)
+        & withSender successor
 
       comment "Checking that ownership transfer really occured"
       call contract (Call @"Set_admin") admin
-        & withSender (AddressResolved successor)
+        & withSender successor
 
   , nettestScenarioCaps "Non-admin cannot set new admin" $ do
       admin <- newAddress "admin"
       successor <- newAddress "successor"
       contract <- originateFn admin
       call contract (Call @"Set_admin") successor
-        & expectError errNotAdmin
+        & expectError contract errNotAdmin
 
   , nettestScenarioCaps "Cannot accept ownership before prior transfer of it" $ do
       admin <- newAddress "admin"
       contract <- originateFn admin
 
       call contract (Call @"Confirm_admin") ()
-        & expectError noPendingAdmin
+        & expectError contract noPendingAdmin
 
   , nettestScenarioCaps "Not pending admin cannot confirm ownership" $ do
       admin <- newAddress "admin"
@@ -61,8 +61,8 @@ adminOwnershipTransferChecks originateFn = testGroup "Admin functionality"
       contract <- originateFn admin
 
       call contract (Call @"Set_admin") successor
-        & withSender (AddressResolved admin)
+        & withSender admin
       call contract (Call @"Confirm_admin") ()
-        & expectError notPendingAdmin
+        & expectError contract notPendingAdmin
 
   ]

--- a/packages/minter-contracts/test-hs/Test/Swaps/Allowlisted.hs
+++ b/packages/minter-contracts/test-hs/Test/Swaps/Allowlisted.hs
@@ -38,7 +38,7 @@ test_AllowlistChecks = allowlistChecks
       [ AllowlistRestrictionCase
         { allowlistError = errSwapOfferedNotAllowlisted
         , allowlistRunRestrictedAction = \(alice, tokenId) swap fa2 ->
-            withSender (AddressResolved alice) $
+            withSender alice $
               call swap (Call @"Start") SwapOffer
                 { assetsOffered = [mkFA2Assets fa2 [(tokenId, 1)]]
                 , assetsRequested = []
@@ -47,7 +47,7 @@ test_AllowlistChecks = allowlistChecks
       , AllowlistRestrictionCase
         { allowlistError = errSwapRequestedNotAllowlisted
         , allowlistRunRestrictedAction = \(alice, tokenId) swap fa2 ->
-            withSender (AddressResolved alice) $
+            withSender alice $
               call swap (Call @"Start") SwapOffer
                 { assetsOffered = []
                 , assetsRequested = [mkFA2Assets fa2 [(tokenId, 1)]]
@@ -68,19 +68,19 @@ test_Integrational = testGroup "Integrational"
       (swap, admin) <- originateWithAdmin originateAllowlistedSwap
       fa2 <- originateFA2 "fa2" setup [swap]
 
-      withSender (AddressResolved admin) $
+      withSender admin $
         call swap (Call @"Update_allowed") (mkAllowlistParam [fa2])
 
       assertingBalanceDeltas fa2
         [ (alice, tokenId) -: -3
         , (bob, tokenId) -: 3
         ] $ do
-          withSender (AddressResolved alice) $
+          withSender alice $
             call swap (Call @"Start") SwapOffer
               { assetsOffered = [mkFA2Assets fa2 [(tokenId, 10)]]
               , assetsRequested = [mkFA2Assets fa2 [(tokenId, 7)]]
               }
-          withSender (AddressResolved bob) $
+          withSender bob $
             call swap (Call @"Accept") (SwapId 0)
 
   ]

--- a/packages/minter-contracts/test-hs/Test/Swaps/Basic.hs
+++ b/packages/minter-contracts/test-hs/Test/Swaps/Basic.hs
@@ -40,12 +40,12 @@ simpleHappyPaths = testGroup "Simple happy paths"
         , (bob, tokenId1) -: 10
         , (bob, tokenId2) -: -5
         ] $ do
-          withSender (AddressResolved alice) $
+          withSender alice $
             call swap (Call @"Start") SwapOffer
               { assetsOffered = [mkFA2Assets fa2 [(tokenId1, 10)]]
               , assetsRequested = [mkFA2Assets fa2 [(tokenId2, 5)]]
               }
-          withSender (AddressResolved bob) $
+          withSender bob $
             call swap (Call @"Accept") (SwapId 0)
 
   , nettestScenarioCaps "Simple cancelled swap" $ do
@@ -59,12 +59,12 @@ simpleHappyPaths = testGroup "Simple happy paths"
         [ (alice, tokenId1) -: 0
         , (alice, tokenId2) -: 0
         ] $ do
-          withSender (AddressResolved alice) $
+          withSender alice $
             call swap (Call @"Start") SwapOffer
               { assetsOffered = [mkFA2Assets fa2 [(tokenId1, 10)]]
               , assetsRequested = [mkFA2Assets fa2 [(tokenId2, 5)]]
               }
-          withSender (AddressResolved alice) $
+          withSender alice $
             call swap (Call @"Cancel") (SwapId 0)
   ]
 
@@ -77,10 +77,10 @@ statusChecks = testGroup "Statuses"
       call swap (Call @"Accept") (SwapId 0)
 
       call swap (Call @"Accept") (SwapId 0)
-        & expectError errSwapFinished
+        & expectError swap errSwapFinished
 
       call swap (Call @"Cancel") (SwapId 0)
-        & expectError errSwapFinished
+        & expectError swap errSwapFinished
 
   , nettestScenarioCaps "Operations with cancelled swap fail" $ do
       swap <- originateSwap
@@ -89,10 +89,10 @@ statusChecks = testGroup "Statuses"
       call swap (Call @"Cancel") (SwapId 0)
 
       call swap (Call @"Accept") (SwapId 0)
-        & expectError errSwapCancelled
+        & expectError swap errSwapCancelled
 
       call swap (Call @"Cancel") (SwapId 0)
-        & expectError errSwapCancelled
+        & expectError swap errSwapCancelled
   ]
 
 swapIdChecks :: TestTree
@@ -104,7 +104,7 @@ swapIdChecks = testGroup "SwapIds"
       swap <- originateSwap
       fa2 <- originateFA2 "fa2" setup [swap]
 
-      withSender (AddressResolved alice) $
+      withSender alice $
         for_ [tokenId1, tokenId2, tokenId3] $ \tokenId ->
           call swap (Call @"Start") SwapOffer
             { assetsOffered = []
@@ -116,7 +116,7 @@ swapIdChecks = testGroup "SwapIds"
         , (bob, tokenId2) -: -0
         , (bob, tokenId3) -: -1
         ] $ do
-          withSender (AddressResolved bob) $ do
+          withSender bob $ do
             call swap (Call @"Accept") (SwapId 0)
             call swap (Call @"Accept") (SwapId 2)
 
@@ -124,16 +124,16 @@ swapIdChecks = testGroup "SwapIds"
       swap <- originateSwap
 
       call swap (Call @"Accept") (SwapId 0)
-        & expectError errSwapNotExist
+        & expectError swap errSwapNotExist
       call swap (Call @"Cancel") (SwapId 0)
-        & expectError errSwapNotExist
+        & expectError swap errSwapNotExist
 
       call swap (Call @"Start") $ SwapOffer [] []
 
       call swap (Call @"Accept") (SwapId 1)
-        & expectError errSwapNotExist
+        & expectError swap errSwapNotExist
       call swap (Call @"Cancel") (SwapId 1)
-        & expectError errSwapNotExist
+        & expectError swap errSwapNotExist
 
       call swap (Call @"Accept") (SwapId 0)
   ]
@@ -146,15 +146,15 @@ authorizationChecks = testGroup "Authorization checks"
       let !SNil = sTokens setup
       swap <- originateSwap
 
-      withSender (AddressResolved alice) $
+      withSender alice $
         call swap (Call @"Start") $ SwapOffer [] []
 
       call swap (Call @"Cancel") (SwapId 0)
-        & expectError errNotSwapSeller
+        & expectError swap errNotSwapSeller
 
-      withSender (AddressResolved bob) $
+      withSender bob $
         call swap (Call @"Cancel") (SwapId 0)
-        & expectError errNotSwapSeller
+        & expectError swap errNotSwapSeller
   ]
 
 invalidFA2sChecks :: TestTree
@@ -175,22 +175,22 @@ invalidFA2sChecks = testGroup "Invalid FA2s"
         swap <- originateSwap
 
         comment "Checking offered FA2"
-        withSender (AddressResolved alice) $
+        withSender alice $
           call swap (Call @"Start") SwapOffer
             { assetsOffered = [mkFA2Assets fa2 [(tokenId1, 1)]]
             , assetsRequested = []
             }
-            & expectError errSwapOfferedFA2Invalid
+            & expectError swap errSwapOfferedFA2Invalid
 
         comment "Checking requested FA2"
-        withSender (AddressResolved alice) $ do
+        withSender alice $ do
           call swap (Call @"Start") SwapOffer
             { assetsOffered = []
             , assetsRequested = [mkFA2Assets fa2 [(tokenId1, 1)]]
             }
 
           call swap (Call @"Accept") (SwapId 0)
-            & expectError errSwapRequestedFA2Invalid
+            & expectError swap errSwapRequestedFA2Invalid
   ]
 
 complexCases :: TestTree
@@ -215,7 +215,7 @@ complexCases = testGroup "Complex cases"
         [ (alice, tokenId1) -: -1000
         , (bob, tokenId1) -: 1000
         ] $ do
-          withSender (AddressResolved alice) $
+          withSender alice $
             call swap (Call @"Start") SwapOffer
               { assetsOffered =
                   [ mkFA2Assets fa2_1
@@ -232,7 +232,7 @@ complexCases = testGroup "Complex cases"
                     ]
                   ]
               }
-          withSender (AddressResolved bob) $
+          withSender bob $
             call swap (Call @"Accept") (SwapId 0)
 
   ]

--- a/packages/minter-contracts/test-hs/Test/Util.hs
+++ b/packages/minter-contracts/test-hs/Test/Util.hs
@@ -11,6 +11,7 @@ module Test.Util
   , assertingBalanceDeltas
   , mkAllowlistParam
   , originateWithAdmin
+  , clevelandProp
 
     -- Re-exports
   , Sized
@@ -26,6 +27,7 @@ import Data.Type.Ordinal (ordToNatural)
 import Fmt ((+|), (|+))
 import GHC.TypeLits (Symbol)
 import GHC.TypeNats (Nat, type (+))
+import Hedgehog (MonadTest)
 
 import Lorentz.Test.Consumer
 import Lorentz.Value
@@ -33,6 +35,7 @@ import Lorentz.Value
 import qualified Indigo.Contracts.FA2Sample as FA2
 import qualified Lorentz.Contracts.Spec.FA2Interface as FA2
 import Morley.Nettest
+import Morley.Nettest.Pure (PureM, runEmulated)
 
 -- | An alias for pair constructor.
 infix 0 -:
@@ -192,3 +195,7 @@ originateWithAdmin originateFn = do
   admin <- newAddress "admin"
   swaps <- originateFn admin
   return (swaps, admin)
+
+-- | Create a hedgehog property-based test from a cleveland scenario.
+clevelandProp :: (MonadIO m, MonadTest m) => EmulatedT PureM () -> m ()
+clevelandProp = nettestTestProp . runEmulated . uncapsNettestEmulated

--- a/packages/minter-contracts/test-hs/Test/Util.hs
+++ b/packages/minter-contracts/test-hs/Test/Util.hs
@@ -18,7 +18,6 @@ module Test.Util
 
 
 import qualified Data.Foldable as F
-import Data.Kind (Type)
 import qualified Data.Map as Map
 import Data.Sized (Sized)
 import qualified Data.Sized as Sized
@@ -155,7 +154,7 @@ assertingBalanceDeltas fa2 indicedDeltas action = do
   pullBalance consumer
 
   balancesRes <- map (map FA2.briBalance) . fromVal <$>
-    getStorage (AddressResolved $ toAddress consumer)
+    getStorage consumer
   (balancesAfter, balancesBefore) <- case balancesRes of
     [balancesAfter, balancesBefore] ->
       return (balancesAfter, balancesBefore)


### PR DESCRIPTION
This PR adds:
* Lorentz bindings for the editions contract
* Property-based tests for the invariants in the [editions contract spec](https://github.com/tqtezos/minter-sdk/blob/2ad6b155e27f9f5e5a0730f125875c821a36a1f0/packages/minter-contracts/ligo/src/minter_collection/editions/README.md).


Also took the opportunity to bump all the morley-related dependencies.