### PR TITLE
Export TypeScript Tezos type-aliases

### DIFF
--- a/packages/minter-contracts/src/generate-index.ts
+++ b/packages/minter-contracts/src/generate-index.ts
@@ -40,7 +40,7 @@ const generateIndex = (codeFiles: string[]) => {
     .map(fileName => `  ${fileNameToContractType(fileName)},\n  ${fileNameToCodeObject(fileName)},`)
     .join('\n');
 
-  return `${codeImports}\n\nexport {\n${exports}\n};\n`;
+  return `${codeImports}\n\nexport {\n${exports}\n};\nexport * as TypeAliases from './type-aliases';\n`;
 };
 
 try {


### PR DESCRIPTION
Allow consumers to import the type aliases used by the type generator such that the following type checks:

```ts
import { TypeAliases } from '@tqtezos/minter-contracts';

const f = (address: TypeAliases.address) => null;
f(TypeAliases.tas.address('tz1...'));
```