### PR TITLE
Bump used Cleveland version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,7 @@ jobs:
         name: ligo-bin
         path: packages/minter-contracts/bin.tar.gz
         retention-days: 1
-  
+
   generate-types:
     name: Generate Types
     runs-on: ubuntu-latest
@@ -100,7 +100,7 @@ jobs:
       with:
         name: bin-ts
         path: packages/minter-contracts
-    
+
     - run: tar -xzf bin-ts.tar.gz
       name: Unpack generated TypeScript types
       working-directory: packages/minter-contracts
@@ -123,18 +123,18 @@ jobs:
         path: ~/.stack
         key: stack
 
-    - uses: actions/setup-haskell@v1.1.4
+    - uses: haskell/actions/setup@v2
       name: Setup Haskell Stack
       with:
         ghc-version: 9.0.1  # higher than necessary, but is cached in the runner
         stack-version: 2.3
-    
+
     - uses: actions/download-artifact@v2
       name: Download compiled contracts
       with:
         name: ligo-bin
         path: packages/minter-contracts
-    
+
     - run: tar -xzf bin.tar.gz
       name: Unpack compiled contracts
       working-directory: packages/minter-contracts

--- a/packages/minter-contracts/src-hs/Lorentz/Contracts/EnglishAuction/Contracts.hs
+++ b/packages/minter-contracts/src-hs/Lorentz/Contracts/EnglishAuction/Contracts.hs
@@ -1,0 +1,107 @@
+-- | English auction contracts.
+module Lorentz.Contracts.EnglishAuction.Contracts where
+
+import Lorentz
+
+import qualified Lorentz.Contracts.AllowlistSimple as AllowlistSimple
+import qualified Lorentz.Contracts.AllowlistToken as AllowlistToken
+import qualified Lorentz.Contracts.EnglishAuction.FA2 as AuctionFA2
+import qualified Lorentz.Contracts.EnglishAuction.FA2FixedFee as AuctionFA2FixedFee
+import qualified Lorentz.Contracts.EnglishAuction.Tez as AuctionTez
+import qualified Lorentz.Contracts.EnglishAuction.TezFixedFee as AuctionTezFixedFee
+import qualified Lorentz.Contracts.EnglishAuction.TezPermit as AuctionTezPermit
+import Lorentz.Contracts.MinterSdk
+import qualified Lorentz.Contracts.NoAllowlist as NoAllowlist
+import Lorentz.Test.Import (embedContractM)
+
+-- AuctionFA2
+----------------------------------------------------------------------------
+
+englishAuctionFA2Contract
+  :: Contract
+      (AuctionFA2.AuctionEntrypoints NoAllowlist.Entrypoints)
+      (AuctionFA2.AuctionStorage NoAllowlist.Allowlist)
+englishAuctionFA2Contract =
+  $$(embedContractM (inBinFolder "english_auction_fa2.tz"))
+
+auctionFA2AllowlistedContract
+  :: Contract
+      (AuctionFA2.AuctionEntrypoints AllowlistSimple.Entrypoints)
+      (AuctionFA2.AuctionStorage AllowlistSimple.Allowlist)
+auctionFA2AllowlistedContract =
+  $$(embedContractM (inBinFolder "english_auction_fa2_allowlisted.tz"))
+
+auctionFA2AllowlistedTokenContract
+  :: Contract
+      (AuctionFA2.AuctionEntrypoints AllowlistToken.Entrypoints)
+      (AuctionFA2.AuctionStorage AllowlistToken.Allowlist)
+auctionFA2AllowlistedTokenContract =
+  $$(embedContractM (inBinFolder "english_auction_fa2_allowlisted_token.tz"))
+
+-- FA2FixedFee
+----------------------------------------------------------------------------
+
+englishAuctionFA2FixedFeeContract
+  :: Contract
+      (AuctionFA2.AuctionEntrypoints NoAllowlist.Entrypoints)
+      AuctionFA2FixedFee.AuctionStorage
+englishAuctionFA2FixedFeeContract =
+  $$(embedContractM (inBinFolder "english_auction_fa2_fixed_fee.tz"))
+
+-- Tez
+----------------------------------------------------------------------------
+
+auctionTezContract
+  :: Contract
+      (AuctionTez.AuctionEntrypoints NoAllowlist.Entrypoints)
+      (AuctionTez.AuctionStorage NoAllowlist.Allowlist)
+auctionTezContract =
+  $$(embedContractM (inBinFolder "english_auction_tez.tz"))
+
+auctionTezAllowlistedContract
+  :: Contract
+      (AuctionTez.AuctionEntrypoints AllowlistSimple.Entrypoints)
+      (AuctionTez.AuctionStorage AllowlistSimple.Allowlist)
+auctionTezAllowlistedContract =
+  $$(embedContractM (inBinFolder "english_auction_tez_allowlisted.tz"))
+
+auctionTezAllowlistedTokenContract
+  :: Contract
+      (AuctionTez.AuctionEntrypoints AllowlistToken.Entrypoints)
+      (AuctionTez.AuctionStorage AllowlistToken.Allowlist)
+auctionTezAllowlistedTokenContract =
+  $$(embedContractM (inBinFolder "english_auction_tez_allowlisted_token.tz"))
+
+-- TezFixedFee
+----------------------------------------------------------------------------
+
+englishAuctionTezFixedFeeContract
+  :: Contract
+      (AuctionTezFixedFee.AuctionEntrypoints NoAllowlist.Entrypoints)
+      AuctionTezFixedFee.AuctionStorage
+englishAuctionTezFixedFeeContract =
+  $$(embedContractM (inBinFolder "english_auction_tez_fixed_fee.tz"))
+
+-- TezPermit
+----------------------------------------------------------------------------
+
+auctionTezPermitContract
+  :: Contract
+      (AuctionTezPermit.PermitAuctionEntrypoints NoAllowlist.Entrypoints)
+      (AuctionTezPermit.PermitAuctionStorage NoAllowlist.Allowlist)
+auctionTezPermitContract =
+  $$(embedContractM (inBinFolder "english_auction_tez_permit.tz"))
+
+auctionTezPermitAllowlistedContract
+  :: Contract
+      (AuctionTezPermit.PermitAuctionEntrypoints AllowlistSimple.Entrypoints)
+      (AuctionTezPermit.PermitAuctionStorage AllowlistSimple.Allowlist)
+auctionTezPermitAllowlistedContract =
+  $$(embedContractM (inBinFolder "english_auction_tez_permit_allowlisted.tz"))
+
+auctionTezPermitAllowlistedTokenContract
+  :: Contract
+      (AuctionTezPermit.PermitAuctionEntrypoints AllowlistToken.Entrypoints)
+      (AuctionTezPermit.PermitAuctionStorage AllowlistToken.Allowlist)
+auctionTezPermitAllowlistedTokenContract =
+  $$(embedContractM (inBinFolder "english_auction_tez_permit_allowlisted_token.tz"))

--- a/packages/minter-contracts/src-hs/Lorentz/Contracts/EnglishAuction/FA2.hs
+++ b/packages/minter-contracts/src-hs/Lorentz/Contracts/EnglishAuction/FA2.hs
@@ -4,15 +4,9 @@ module Lorentz.Contracts.EnglishAuction.FA2 where
 import Lorentz
 
 import Fmt (Buildable(..), genericF)
-import qualified Lorentz.Contracts.AllowlistSimple as AllowlistSimple
-import qualified Lorentz.Contracts.AllowlistToken as AllowlistToken
 import Lorentz.Contracts.EnglishAuction.Common
-import Lorentz.Contracts.MinterSdk
-import qualified Lorentz.Contracts.NoAllowlist as NoAllowlist
 import Lorentz.Contracts.PausableAdminOption
 import Lorentz.Contracts.Spec.FA2Interface
-import Michelson.Test.Import (embedContractM)
-import qualified Michelson.Typed as T
 
 -- Types
 ----------------------------------------------------------------------------
@@ -125,30 +119,6 @@ instance
   ) =>
     ParameterHasEntrypoints (AuctionEntrypoints al) where
   type ParameterEntrypointsDerivation (AuctionEntrypoints al) = EpdDelegate
-
--- Contract
-----------------------------------------------------------------------------
-
-englishAuctionFA2Contract
-  :: T.Contract
-      (ToT (AuctionEntrypoints NoAllowlist.Entrypoints))
-      (ToT (AuctionStorage NoAllowlist.Allowlist))
-englishAuctionFA2Contract =
-  $$(embedContractM (inBinFolder "english_auction_fa2.tz"))
-
-auctionFA2AllowlistedContract
-  :: T.Contract
-      (ToT (AuctionEntrypoints AllowlistSimple.Entrypoints))
-      (ToT (AuctionStorage AllowlistSimple.Allowlist))
-auctionFA2AllowlistedContract =
-  $$(embedContractM (inBinFolder "english_auction_fa2_allowlisted.tz"))
-
-auctionFA2AllowlistedTokenContract
-  :: T.Contract
-      (ToT (AuctionEntrypoints AllowlistToken.Entrypoints))
-      (ToT (AuctionStorage AllowlistToken.Allowlist))
-auctionFA2AllowlistedTokenContract =
-  $$(embedContractM (inBinFolder "english_auction_fa2_allowlisted_token.tz"))
 
 -- Errors
 ----------------------------------------------------------------------------

--- a/packages/minter-contracts/src-hs/Lorentz/Contracts/EnglishAuction/FA2FixedFee.hs
+++ b/packages/minter-contracts/src-hs/Lorentz/Contracts/EnglishAuction/FA2FixedFee.hs
@@ -9,9 +9,6 @@ module Lorentz.Contracts.EnglishAuction.FA2FixedFee
   , AuctionStorage(..)
   , initAuctionStorage
   , AuctionFA2.AuctionEntrypoints(..)
-
-  -- * Contract
-  , englishAuctionFA2FixedFeeContract
   ) where
 
 import Lorentz
@@ -20,10 +17,7 @@ import Fmt (Buildable(..), genericF)
 import Lorentz.Contracts.EnglishAuction.Common
 import qualified Lorentz.Contracts.EnglishAuction.FA2 as AuctionFA2
 import Lorentz.Contracts.MinterSdk
-import qualified Lorentz.Contracts.NoAllowlist as NoAllowlist
 import Lorentz.Contracts.PausableAdminOption
-import Michelson.Test.Import (embedContractM)
-import qualified Michelson.Typed as T
 
 -- Types
 ----------------------------------------------------------------------------
@@ -55,12 +49,3 @@ initAuctionStorage feeData as bc = AuctionStorage
   , allowlist = ()
   , fee = feeData
   }
-
--- Contract
-----------------------------------------------------------------------------
-
-englishAuctionFA2FixedFeeContract
-  :: T.Contract
-      (ToT (AuctionFA2.AuctionEntrypoints NoAllowlist.Entrypoints))
-      (ToT AuctionStorage)
-englishAuctionFA2FixedFeeContract = $$(embedContractM (inBinFolder "english_auction_fa2_fixed_fee.tz"))

--- a/packages/minter-contracts/src-hs/Lorentz/Contracts/EnglishAuction/Tez.hs
+++ b/packages/minter-contracts/src-hs/Lorentz/Contracts/EnglishAuction/Tez.hs
@@ -4,14 +4,8 @@ module Lorentz.Contracts.EnglishAuction.Tez where
 import Lorentz
 
 import Fmt (Buildable(..), genericF)
-import qualified Lorentz.Contracts.AllowlistSimple as AllowlistSimple
-import qualified Lorentz.Contracts.AllowlistToken as AllowlistToken
 import Lorentz.Contracts.EnglishAuction.Common
-import Lorentz.Contracts.MinterSdk
-import qualified Lorentz.Contracts.NoAllowlist as NoAllowlist
 import Lorentz.Contracts.PausableAdminOption
-import Michelson.Test.Import (embedContractM)
-import qualified Michelson.Typed as T
 
 -- Types
 ----------------------------------------------------------------------------
@@ -117,30 +111,6 @@ instance
   ) =>
     ParameterHasEntrypoints (AuctionEntrypoints al) where
   type ParameterEntrypointsDerivation (AuctionEntrypoints al) = EpdDelegate
-
--- Contract
-----------------------------------------------------------------------------
-
-auctionTezContract
-  :: T.Contract
-      (ToT (AuctionEntrypoints NoAllowlist.Entrypoints))
-      (ToT (AuctionStorage NoAllowlist.Allowlist))
-auctionTezContract =
-  $$(embedContractM (inBinFolder "english_auction_tez.tz"))
-
-auctionTezAllowlistedContract
-  :: T.Contract
-      (ToT (AuctionEntrypoints AllowlistSimple.Entrypoints))
-      (ToT (AuctionStorage AllowlistSimple.Allowlist))
-auctionTezAllowlistedContract =
-  $$(embedContractM (inBinFolder "english_auction_tez_allowlisted.tz"))
-
-auctionTezAllowlistedTokenContract
-  :: T.Contract
-      (ToT (AuctionEntrypoints AllowlistToken.Entrypoints))
-      (ToT (AuctionStorage AllowlistToken.Allowlist))
-auctionTezAllowlistedTokenContract =
-  $$(embedContractM (inBinFolder "english_auction_tez_allowlisted_token.tz"))
 
 -- Errors
 ----------------------------------------------------------------------------

--- a/packages/minter-contracts/src-hs/Lorentz/Contracts/EnglishAuction/TezFixedFee.hs
+++ b/packages/minter-contracts/src-hs/Lorentz/Contracts/EnglishAuction/TezFixedFee.hs
@@ -8,9 +8,6 @@ module Lorentz.Contracts.EnglishAuction.TezFixedFee
   , initAuctionStorage
   , AuctionTez.AuctionWithoutConfigureEntrypoints(..)
   , AuctionTez.AuctionEntrypoints(..)
-
-  -- * Contract
-  , englishAuctionTezFixedFeeContract
   ) where
 
 import Lorentz
@@ -19,10 +16,7 @@ import Fmt (Buildable(..), genericF)
 import Lorentz.Contracts.EnglishAuction.Common
 import qualified Lorentz.Contracts.EnglishAuction.Tez as AuctionTez
 import Lorentz.Contracts.MinterSdk
-import qualified Lorentz.Contracts.NoAllowlist as NoAllowlist
 import Lorentz.Contracts.PausableAdminOption
-import Michelson.Test.Import (embedContractM)
-import qualified Michelson.Typed as T
 
 -- Types
 ----------------------------------------------------------------------------
@@ -52,12 +46,3 @@ initAuctionStorage feeData as = AuctionStorage
   , allowlist = ()
   , fee = feeData
   }
-
--- Contract
-----------------------------------------------------------------------------
-
-englishAuctionTezFixedFeeContract
-  :: T.Contract
-      (ToT (AuctionTez.AuctionEntrypoints NoAllowlist.Entrypoints))
-      (ToT AuctionStorage)
-englishAuctionTezFixedFeeContract = $$(embedContractM (inBinFolder "english_auction_tez_fixed_fee.tz"))

--- a/packages/minter-contracts/src-hs/Lorentz/Contracts/EnglishAuction/TezPermit.hs
+++ b/packages/minter-contracts/src-hs/Lorentz/Contracts/EnglishAuction/TezPermit.hs
@@ -3,15 +3,8 @@ module Lorentz.Contracts.EnglishAuction.TezPermit where
 
 import Lorentz
 
-import qualified Lorentz.Contracts.AllowlistSimple as AllowlistSimple
-import qualified Lorentz.Contracts.AllowlistToken as AllowlistToken
-import Lorentz.Contracts.MinterSdk
-import qualified Lorentz.Contracts.NoAllowlist as NoAllowlist
-import Lorentz.Contracts.PausableAdminOption
-import Michelson.Test.Import (embedContractM)
-import qualified Michelson.Typed as T
-
 import Lorentz.Contracts.EnglishAuction.Tez
+import Lorentz.Contracts.PausableAdminOption
 
 -- Types
 ----------------------------------------------------------------------------
@@ -63,30 +56,6 @@ instance
   ) =>
   ParameterHasEntrypoints (PermitAuctionEntrypoints al) where
   type ParameterEntrypointsDerivation (PermitAuctionEntrypoints al) = EpdDelegate
-
--- Contract
-----------------------------------------------------------------------------
-
-auctionTezPermitContract
-  :: T.Contract
-      (ToT (PermitAuctionEntrypoints NoAllowlist.Entrypoints))
-      (ToT (PermitAuctionStorage NoAllowlist.Allowlist))
-auctionTezPermitContract =
-  $$(embedContractM (inBinFolder "english_auction_tez_permit.tz"))
-
-auctionTezPermitAllowlistedContract
-  :: T.Contract
-      (ToT (PermitAuctionEntrypoints AllowlistSimple.Entrypoints))
-      (ToT (PermitAuctionStorage AllowlistSimple.Allowlist))
-auctionTezPermitAllowlistedContract =
-  $$(embedContractM (inBinFolder "english_auction_tez_permit_allowlisted.tz"))
-
-auctionTezPermitAllowlistedTokenContract
-  :: T.Contract
-      (ToT (PermitAuctionEntrypoints AllowlistToken.Entrypoints))
-      (ToT (PermitAuctionStorage AllowlistToken.Allowlist))
-auctionTezPermitAllowlistedTokenContract =
-  $$(embedContractM (inBinFolder "english_auction_tez_permit_allowlisted_token.tz"))
 
 -- Errors
 ----------------------------------------------------------------------------

--- a/packages/minter-contracts/src-hs/Lorentz/Contracts/Marketplace/Contracts.hs
+++ b/packages/minter-contracts/src-hs/Lorentz/Contracts/Marketplace/Contracts.hs
@@ -1,0 +1,93 @@
+-- | Lorentz marketplace contracts.
+module Lorentz.Contracts.Marketplace.Contracts where
+
+import Lorentz
+
+import qualified Lorentz.Contracts.AllowlistSimple as AllowlistSimple
+import qualified Lorentz.Contracts.AllowlistToken as AllowlistToken
+import qualified Lorentz.Contracts.Marketplace.FA2 as MarketFA2
+import qualified Lorentz.Contracts.Marketplace.FA2FixedFee as MarketFA2FixedFee
+import qualified Lorentz.Contracts.Marketplace.Tez as MarketTez
+import qualified Lorentz.Contracts.Marketplace.TezFixedFee as MarketTezFixedFee
+import qualified Lorentz.Contracts.Marketplace.TezOffchain as TezOffchain
+import Lorentz.Contracts.MinterSdk
+import qualified Lorentz.Contracts.NoAllowlist as NoAllowlist
+import Lorentz.Test.Import (embedContractM)
+
+-- FA2
+----------------------------------------------------------------------------
+
+marketplaceContract
+  :: Contract
+      (MarketFA2.MarketplaceEntrypoints NoAllowlist.Entrypoints)
+      (MarketFA2.MarketplaceStorage NoAllowlist.Allowlist)
+marketplaceContract =
+  $$(embedContractM (inBinFolder "fixed_price_sale_market.tz"))
+
+marketplaceAllowlistedContract
+  :: Contract
+      (MarketFA2.MarketplaceEntrypoints AllowlistSimple.Entrypoints)
+      (MarketFA2.MarketplaceStorage AllowlistSimple.Allowlist)
+marketplaceAllowlistedContract =
+  $$(embedContractM (inBinFolder "fixed_price_sale_market_allowlisted.tz"))
+
+marketplaceAllowlistedTokenContract
+  :: Contract
+      (MarketFA2.MarketplaceEntrypoints AllowlistToken.Entrypoints)
+      (MarketFA2.MarketplaceStorage AllowlistToken.Allowlist)
+marketplaceAllowlistedTokenContract =
+  $$(embedContractM (inBinFolder "fixed_price_sale_market_allowlisted_token.tz"))
+
+-- FA2FixedFee
+----------------------------------------------------------------------------
+
+marketplaceFixedFeeContract
+  :: Contract
+      (MarketFA2.MarketplaceEntrypoints NoAllowlist.Entrypoints)
+      (MarketFA2FixedFee.MarketplaceStorage NoAllowlist.Allowlist)
+marketplaceFixedFeeContract =
+  $$(embedContractM (inBinFolder "fixed_price_sale_market_fixed_fee.tz"))
+
+-- Tez
+----------------------------------------------------------------------------
+
+marketplaceTezContract
+  :: Contract
+      (MarketTez.MarketplaceTezEntrypoints NoAllowlist.Entrypoints)
+      (MarketTez.MarketplaceTezStorage NoAllowlist.Allowlist)
+marketplaceTezContract =
+  $$(embedContractM (inBinFolder "fixed_price_sale_market_tez.tz"))
+
+marketplaceTezAllowlistedContract
+  :: Contract
+      (MarketTez.MarketplaceTezEntrypoints AllowlistSimple.Entrypoints)
+      (MarketTez.MarketplaceTezStorage AllowlistSimple.Allowlist)
+marketplaceTezAllowlistedContract =
+  $$(embedContractM (inBinFolder "fixed_price_sale_market_tez_allowlisted.tz"))
+
+marketplaceTezAllowlistedTokenContract
+  :: Contract
+      (MarketTez.MarketplaceTezEntrypoints AllowlistToken.Entrypoints)
+      (MarketTez.MarketplaceTezStorage AllowlistToken.Allowlist)
+marketplaceTezAllowlistedTokenContract =
+  $$(embedContractM (inBinFolder "fixed_price_sale_market_tez_allowlisted_token.tz"))
+
+-- TezFixedFee
+----------------------------------------------------------------------------
+
+marketplaceTezFixedFeeContract
+  :: Contract
+      (MarketTez.MarketplaceTezEntrypoints NoAllowlist.Entrypoints)
+      (MarketTezFixedFee.MarketplaceTezStorage NoAllowlist.Allowlist)
+marketplaceTezFixedFeeContract =
+  $$(embedContractM (inBinFolder "fixed_price_sale_tez_fixed_fee.tz"))
+
+-- TezOffchain
+----------------------------------------------------------------------------
+
+marketplaceTezOffchainContract
+  :: Contract
+      (TezOffchain.MarketplaceTezOffchainEntrypoints NoAllowlist.Entrypoints)
+      (TezOffchain.MarketplaceTezOffchainStorage NoAllowlist.Allowlist)
+marketplaceTezOffchainContract =
+  $$(embedContractM (inBinFolder "fixed_price_sale_market_tez_offchain.tz"))

--- a/packages/minter-contracts/src-hs/Lorentz/Contracts/Marketplace/FA2.hs
+++ b/packages/minter-contracts/src-hs/Lorentz/Contracts/Marketplace/FA2.hs
@@ -4,14 +4,8 @@ module Lorentz.Contracts.Marketplace.FA2 where
 import Fmt (Buildable(..), genericF)
 import Lorentz
 
-import qualified Lorentz.Contracts.AllowlistSimple as AllowlistSimple
-import qualified Lorentz.Contracts.AllowlistToken as AllowlistToken
-import Lorentz.Contracts.MinterSdk
-import qualified Lorentz.Contracts.NoAllowlist as NoAllowlist
 import Lorentz.Contracts.PausableAdminOption
 import Lorentz.Contracts.Spec.FA2Interface
-import Michelson.Test.Import (embedContractM)
-import qualified Michelson.Typed as T
 
 -- Types
 ----------------------------------------------------------------------------
@@ -118,30 +112,3 @@ instance
   ) =>
     ParameterHasEntrypoints (MarketplaceEntrypoints al) where
   type ParameterEntrypointsDerivation (MarketplaceEntrypoints al) = EpdDelegate
-
--- Contract
-----------------------------------------------------------------------------
-
-marketplaceContract
-  :: T.Contract
-      (ToT (MarketplaceEntrypoints NoAllowlist.Entrypoints))
-      (ToT (MarketplaceStorage NoAllowlist.Allowlist))
-marketplaceContract =
-  $$(embedContractM (inBinFolder "fixed_price_sale_market.tz"))
-
-marketplaceAllowlistedContract
-  :: T.Contract
-      (ToT (MarketplaceEntrypoints AllowlistSimple.Entrypoints))
-      (ToT (MarketplaceStorage AllowlistSimple.Allowlist))
-marketplaceAllowlistedContract =
-  $$(embedContractM (inBinFolder "fixed_price_sale_market_allowlisted.tz"))
-
-marketplaceAllowlistedTokenContract
-  :: T.Contract
-      (ToT (MarketplaceEntrypoints AllowlistToken.Entrypoints))
-      (ToT (MarketplaceStorage AllowlistToken.Allowlist))
-marketplaceAllowlistedTokenContract =
-  $$(embedContractM (inBinFolder "fixed_price_sale_market_allowlisted_token.tz"))
-
--- Errors
-----------------------------------------------------------------------------

--- a/packages/minter-contracts/src-hs/Lorentz/Contracts/Marketplace/FA2FixedFee.hs
+++ b/packages/minter-contracts/src-hs/Lorentz/Contracts/Marketplace/FA2FixedFee.hs
@@ -9,9 +9,6 @@ module Lorentz.Contracts.Marketplace.FA2FixedFee
   , MarketplaceStorage(..)
   , MarketFA2.MarketplaceEntrypoints(..)
   , initMarketplaceStorage
-
-  -- * Contract
-  , marketplaceFixedFeeContract
   ) where
 
 import Fmt (Buildable(..), genericF)
@@ -19,11 +16,8 @@ import Lorentz
 
 import Lorentz.Contracts.MinterSdk
 import Lorentz.Contracts.PausableAdminOption
-import Michelson.Test.Import (embedContractM)
-import qualified Michelson.Typed as T
 
 import qualified Lorentz.Contracts.Marketplace.FA2 as MarketFA2
-import qualified Lorentz.Contracts.NoAllowlist as NoAllowlist
 
 -- Types
 ----------------------------------------------------------------------------
@@ -50,12 +44,3 @@ initMarketplaceStorage feeData as =
     , allowlist = mempty
     , fee = feeData
     }
-
--- Contract
-----------------------------------------------------------------------------
-
-marketplaceFixedFeeContract
-  :: T.Contract
-      (ToT (MarketFA2.MarketplaceEntrypoints NoAllowlist.Entrypoints))
-      (ToT (MarketplaceStorage NoAllowlist.Allowlist))
-marketplaceFixedFeeContract = $$(embedContractM (inBinFolder "fixed_price_sale_market_fixed_fee.tz"))

--- a/packages/minter-contracts/src-hs/Lorentz/Contracts/Marketplace/Tez.hs
+++ b/packages/minter-contracts/src-hs/Lorentz/Contracts/Marketplace/Tez.hs
@@ -4,14 +4,8 @@ module Lorentz.Contracts.Marketplace.Tez where
 import Fmt (Buildable(..), genericF)
 import Lorentz
 
-import qualified Lorentz.Contracts.AllowlistSimple as AllowlistSimple
-import qualified Lorentz.Contracts.AllowlistToken as AllowlistToken
-import Lorentz.Contracts.MinterSdk
-import qualified Lorentz.Contracts.NoAllowlist as NoAllowlist
 import Lorentz.Contracts.PausableAdminOption
 import Lorentz.Contracts.Spec.FA2Interface
-import Michelson.Test.Import (embedContractM)
-import qualified Michelson.Typed as T
 
 -- Types
 ----------------------------------------------------------------------------
@@ -108,30 +102,6 @@ instance
   ) =>
     ParameterHasEntrypoints (MarketplaceTezEntrypoints al) where
   type ParameterEntrypointsDerivation (MarketplaceTezEntrypoints al) = EpdDelegate
-
--- Contract
-----------------------------------------------------------------------------
-
-marketplaceTezContract
-  :: T.Contract
-      (ToT (MarketplaceTezEntrypoints NoAllowlist.Entrypoints))
-      (ToT (MarketplaceTezStorage NoAllowlist.Allowlist))
-marketplaceTezContract =
-  $$(embedContractM (inBinFolder "fixed_price_sale_market_tez.tz"))
-
-marketplaceTezAllowlistedContract
-  :: T.Contract
-      (ToT (MarketplaceTezEntrypoints AllowlistSimple.Entrypoints))
-      (ToT (MarketplaceTezStorage AllowlistSimple.Allowlist))
-marketplaceTezAllowlistedContract =
-  $$(embedContractM (inBinFolder "fixed_price_sale_market_tez_allowlisted.tz"))
-
-marketplaceTezAllowlistedTokenContract
-  :: T.Contract
-      (ToT (MarketplaceTezEntrypoints AllowlistToken.Entrypoints))
-      (ToT (MarketplaceTezStorage AllowlistToken.Allowlist))
-marketplaceTezAllowlistedTokenContract =
-  $$(embedContractM (inBinFolder "fixed_price_sale_market_tez_allowlisted_token.tz"))
 
 -- Errors
 ----------------------------------------------------------------------------

--- a/packages/minter-contracts/src-hs/Lorentz/Contracts/Marketplace/TezFixedFee.hs
+++ b/packages/minter-contracts/src-hs/Lorentz/Contracts/Marketplace/TezFixedFee.hs
@@ -8,21 +8,14 @@ module Lorentz.Contracts.Marketplace.TezFixedFee
   , MarketplaceTezStorage(..)
   , MarketTez.MarketplaceTezEntrypoints(..)
   , initMarketplaceTezStorage
-
-  -- * Contract
-  , marketplaceTezFixedFeeContract
   ) where
 
 import Fmt (Buildable(..), genericF)
 import Lorentz
 
+import qualified Lorentz.Contracts.Marketplace.Tez as MarketTez
 import Lorentz.Contracts.MinterSdk
 import Lorentz.Contracts.PausableAdminOption
-import Michelson.Test.Import (embedContractM)
-import qualified Michelson.Typed as T
-
-import qualified Lorentz.Contracts.Marketplace.Tez as MarketTez
-import qualified Lorentz.Contracts.NoAllowlist as NoAllowlist
 
 -- Types
 ----------------------------------------------------------------------------
@@ -49,12 +42,3 @@ initMarketplaceTezStorage feeData as =
     , allowlist = mempty
     , fee = feeData
     }
-
--- Contract
-----------------------------------------------------------------------------
-
-marketplaceTezFixedFeeContract
-  :: T.Contract
-      (ToT (MarketTez.MarketplaceTezEntrypoints NoAllowlist.Entrypoints))
-      (ToT (MarketplaceTezStorage NoAllowlist.Allowlist))
-marketplaceTezFixedFeeContract = $$(embedContractM (inBinFolder "fixed_price_sale_tez_fixed_fee.tz"))

--- a/packages/minter-contracts/src-hs/Lorentz/Contracts/Marketplace/TezOffchain.hs
+++ b/packages/minter-contracts/src-hs/Lorentz/Contracts/Marketplace/TezOffchain.hs
@@ -10,22 +10,15 @@ module Lorentz.Contracts.Marketplace.TezOffchain
   , Permit(..)
   , MarketplaceTezOffchainEntrypoints
   , MarketplaceTezOffchainStorage(..)
-
-  -- * Contract
-  , marketplaceTezOffchainContract
   , initMarketplaceTezOffchainStorage
   ) where
 
 import Fmt (Buildable(..), genericF)
 import Lorentz
 
-import Lorentz.Contracts.MinterSdk
 import Lorentz.Contracts.PausableAdminOption
-import Michelson.Test.Import (embedContractM)
-import qualified Michelson.Typed as T
 
 import qualified Lorentz.Contracts.Marketplace.Tez as MarketTez
-import qualified Lorentz.Contracts.NoAllowlist as NoAllowlist
 
 -- Types
 ----------------------------------------------------------------------------
@@ -69,7 +62,7 @@ deriving anyclass instance IsoValue OffchainBuyParam
 deriving anyclass instance HasAnnotation OffchainBuyParam
 instance Buildable OffchainBuyParam where build = genericF
 
-data MarketplaceTezOffchainEntrypoints al 
+data MarketplaceTezOffchainEntrypoints al
   = BaseSale (MarketTez.MarketplaceTezEntrypoints al)
   | Offchain_buy [OffchainBuyParam]
   | Confirm_purchases [PendingPurchase]
@@ -89,15 +82,6 @@ instance
 initMarketplaceTezOffchainStorage :: Monoid al => AdminStorage -> MarketplaceTezOffchainStorage al
 initMarketplaceTezOffchainStorage as =
   MarketplaceTezOffchainStorage
-    { marketplaceStorage = MarketTez.initMarketplaceStorageWithPendingPurchasers as 
+    { marketplaceStorage = MarketTez.initMarketplaceStorageWithPendingPurchasers as
     , counter = 1
     }
-
--- Contract
-----------------------------------------------------------------------------
-
-marketplaceTezOffchainContract
-  :: T.Contract
-      (ToT (MarketplaceTezOffchainEntrypoints NoAllowlist.Entrypoints))
-      (ToT (MarketplaceTezOffchainStorage NoAllowlist.Allowlist))
-marketplaceTezOffchainContract = $$(embedContractM (inBinFolder "fixed_price_sale_market_tez_offchain.tz"))

--- a/packages/minter-contracts/src-hs/Lorentz/Contracts/MinterCollection/Editions/Contracts.hs
+++ b/packages/minter-contracts/src-hs/Lorentz/Contracts/MinterCollection/Editions/Contracts.hs
@@ -1,0 +1,13 @@
+-- | Lorentz editions contract.
+module Lorentz.Contracts.MinterCollection.Editions.Contracts
+  ( editionsContract
+  ) where
+
+import Lorentz
+import Lorentz.Test.Import (embedContractM)
+
+import Lorentz.Contracts.MinterCollection.Editions.Types
+import Lorentz.Contracts.MinterSdk (inBinFolder)
+
+editionsContract :: Contract Entrypoints Storage
+editionsContract = $$(embedContractM (inBinFolder "fa2_multi_nft_token_editions.tz"))

--- a/packages/minter-contracts/src-hs/Lorentz/Contracts/MinterCollection/Editions/Types.hs
+++ b/packages/minter-contracts/src-hs/Lorentz/Contracts/MinterCollection/Editions/Types.hs
@@ -1,5 +1,5 @@
 -- | Lorentz bindings for the editions contract.
-module Lorentz.Contracts.MinterCollection.Editions
+module Lorentz.Contracts.MinterCollection.Editions.Types
   ( EditionInfo
   , EditionId(..)
   , EditionMetadata(..)
@@ -7,16 +7,12 @@ module Lorentz.Contracts.MinterCollection.Editions
   , MintEditionParam(..)
   , DistributeEditionParam(..)
   , Entrypoints(..)
-  , editionsContract
   ) where
 
 import Fmt (Buildable(..), genericF)
 import Lorentz
-import Michelson.Test.Import (embedContractM)
-import qualified Michelson.Typed as T
 
 import qualified Lorentz.Contracts.MinterCollection.Nft.Asset as NftAsset
-import Lorentz.Contracts.MinterSdk (inBinFolder)
 
 type EditionInfo = Map MText ByteString
 
@@ -77,10 +73,3 @@ deriving anyclass instance HasAnnotation Entrypoints
 
 instance ParameterHasEntrypoints Entrypoints where
   type ParameterEntrypointsDerivation Entrypoints = EpdRecursive
-
-----------------------------------------------------------------------------
--- Contract
-----------------------------------------------------------------------------
-
-editionsContract :: T.Contract (ToT Entrypoints) (ToT Storage)
-editionsContract = $$(embedContractM (inBinFolder "fa2_multi_nft_token_editions.tz"))

--- a/packages/minter-contracts/src-hs/Lorentz/Contracts/PausableWallet.hs
+++ b/packages/minter-contracts/src-hs/Lorentz/Contracts/PausableWallet.hs
@@ -3,9 +3,6 @@ module Lorentz.Contracts.PausableWallet where
 import Fmt (Buildable(..), genericF)
 import Lorentz
 import qualified Lorentz.Contracts.SimpleAdmin as SimpleAdmin
-import Michelson.Test.Import (embedContractM)
-import qualified Michelson.Typed as T
-import Lorentz.Contracts.MinterSdk
 
 -- Types
 ----------------------------------------------------------------------------
@@ -17,9 +14,9 @@ deriving anyclass instance HasAnnotation PausableWalletStorage
 instance Buildable PausableWalletStorage where build = genericF
 
 data PausableWalletEntrypoints
-  = Send Mutez 
-  | Default 
-  | Admin SimpleAdmin.AdminEntrypoints 
+  = Send Mutez
+  | Default
+  | Admin SimpleAdmin.AdminEntrypoints
 
 customGeneric "PausableWalletEntrypoints" ligoLayout
 deriving anyclass instance IsoValue PausableWalletEntrypoints
@@ -30,11 +27,4 @@ instance ParameterHasEntrypoints PausableWalletEntrypoints where
 
 
 initPausableWalletStorage :: Address -> PausableWalletStorage
-initPausableWalletStorage = PausableWalletStorage . SimpleAdmin.initAdminStorage 
-
-pausableWalletContract
-  :: T.Contract
-      (ToT PausableWalletEntrypoints)
-      (ToT PausableWalletStorage)
-pausableWalletContract =
-  $$(embedContractM (inBinFolder "pausable_wallet.tz"))
+initPausableWalletStorage = PausableWalletStorage . SimpleAdmin.initAdminStorage

--- a/packages/minter-contracts/src-hs/Lorentz/Contracts/PausableWalletContract.hs
+++ b/packages/minter-contracts/src-hs/Lorentz/Contracts/PausableWalletContract.hs
@@ -1,0 +1,12 @@
+module Lorentz.Contracts.PausableWalletContract where
+
+import Lorentz
+import Lorentz.Contracts.MinterSdk
+import Lorentz.Test.Import (embedContractM)
+
+import Lorentz.Contracts.PausableWallet
+
+pausableWalletContract
+  :: Contract PausableWalletEntrypoints PausableWalletStorage
+pausableWalletContract =
+  $$(embedContractM (inBinFolder "pausable_wallet.tz"))

--- a/packages/minter-contracts/src-hs/Lorentz/Contracts/Swaps/Allowlisted.hs
+++ b/packages/minter-contracts/src-hs/Lorentz/Contracts/Swaps/Allowlisted.hs
@@ -3,10 +3,6 @@ module Lorentz.Contracts.Swaps.Allowlisted where
 
 import Lorentz
 
-import Lorentz.Contracts.MinterSdk
-import Michelson.Test.Import (embedContractM)
-import qualified Michelson.Typed as T
-
 import Lorentz.Contracts.NonPausableSimpleAdmin
 import Lorentz.Contracts.Swaps.Basic
 
@@ -43,14 +39,6 @@ deriving anyclass instance HasAnnotation AllowlistedSwapEntrypoints
 
 instance ParameterHasEntrypoints AllowlistedSwapEntrypoints where
   type ParameterEntrypointsDerivation AllowlistedSwapEntrypoints = EpdDelegate
-
--- Contract
-----------------------------------------------------------------------------
-
-allowlistedSwapsContract
-  :: T.Contract (ToT AllowlistedSwapEntrypoints) (ToT AllowlistedSwapStorage)
-allowlistedSwapsContract =
-  $$(embedContractM (inBinFolder "fa2_allowlisted_swap.tz"))
 
 -- Errors
 ----------------------------------------------------------------------------

--- a/packages/minter-contracts/src-hs/Lorentz/Contracts/Swaps/AllowlistedFee.hs
+++ b/packages/minter-contracts/src-hs/Lorentz/Contracts/Swaps/AllowlistedFee.hs
@@ -3,14 +3,10 @@ module Lorentz.Contracts.Swaps.AllowlistedFee where
 
 import Lorentz
 
-import Lorentz.Contracts.MinterSdk
-import Michelson.Test.Import (embedContractM)
-import qualified Michelson.Typed as T
-
 import Lorentz.Contracts.NonPausableSimpleAdmin
-import Lorentz.Contracts.Swaps.Basic hiding (SwapOffer, SwapOffers, SwapInfo, 
-                                             SwapEntrypoints, SwapStorage, initSwapStorage, 
-                                             mkNOffers, mkSingleOffer) 
+import Lorentz.Contracts.Swaps.Basic hiding
+  (SwapEntrypoints, SwapInfo, SwapOffer, SwapOffers, SwapStorage, initSwapStorage, mkNOffers,
+  mkSingleOffer)
 
 -- Types
 ----------------------------------------------------------------------------
@@ -99,14 +95,6 @@ deriving anyclass instance HasAnnotation AllowlistedFeeSwapEntrypoints
 instance ParameterHasEntrypoints AllowlistedFeeSwapEntrypoints where
   type ParameterEntrypointsDerivation AllowlistedFeeSwapEntrypoints = EpdDelegate
 
--- Contract
-----------------------------------------------------------------------------
-
-allowlistedFeeSwapsContract
-  :: T.Contract (ToT AllowlistedFeeSwapEntrypoints) (ToT AllowlistedFeeSwapStorage)
-allowlistedFeeSwapsContract =
-  $$(embedContractM (inBinFolder "fa2_fee_allowlisted_swap.tz"))
-
 -- Errors
 ----------------------------------------------------------------------------
 
@@ -116,19 +104,19 @@ errSwapOfferedNotAllowlisted = [mt|SWAP_OFFERED_FA2_NOT_ALLOWLISTED|]
 errSwapRequestedNotAllowlisted :: MText
 errSwapRequestedNotAllowlisted = [mt|SWAP_REQUESTED_FA2_NOT_ALLOWLISTED|]
 
-errNoXtzTransferred :: MText 
+errNoXtzTransferred :: MText
 errNoXtzTransferred = [mt|SWAP_REQUESTED_XTZ_INVALID|]
 
 
 -- Helpers
 ----------------------------------------------------------------------------
- 
-mkNOffers :: Natural -> SwapOffer -> SwapOffers 
-mkNOffers n s = SwapOffers 
+
+mkNOffers :: Natural -> SwapOffer -> SwapOffers
+mkNOffers n s = SwapOffers
   {
     swapOffer = s
   , remainingOffers = n
   }
 
-mkSingleOffer :: SwapOffer -> SwapOffers 
+mkSingleOffer :: SwapOffer -> SwapOffers
 mkSingleOffer = mkNOffers 1

--- a/packages/minter-contracts/src-hs/Lorentz/Contracts/Swaps/Basic.hs
+++ b/packages/minter-contracts/src-hs/Lorentz/Contracts/Swaps/Basic.hs
@@ -3,10 +3,7 @@ module Lorentz.Contracts.Swaps.Basic where
 
 import Lorentz
 
-import Lorentz.Contracts.MinterSdk
 import Lorentz.Contracts.Spec.FA2Interface
-import Michelson.Test.Import (embedContractM)
-import qualified Michelson.Typed as T
 
 -- Types
 ----------------------------------------------------------------------------
@@ -81,13 +78,13 @@ customGeneric "SwapStorage" ligoLayout
 deriving anyclass instance IsoValue SwapStorage
 deriving anyclass instance HasAnnotation SwapStorage
 
-incrementSwapId :: SwapId -> SwapId 
+incrementSwapId :: SwapId -> SwapId
 incrementSwapId (SwapId n) = SwapId (n + 1)
 
-initSwapId :: SwapId 
+initSwapId :: SwapId
 initSwapId = SwapId 1
 
-getSwapId :: SwapId -> Natural 
+getSwapId :: SwapId -> Natural
 getSwapId (SwapId n) = n
 
 initSwapStorage :: SwapStorage
@@ -95,12 +92,6 @@ initSwapStorage = SwapStorage
   { nextSwapId = initSwapId
   , swaps = mempty
   }
-
--- Contract
-----------------------------------------------------------------------------
-
-swapsContract :: T.Contract (ToT SwapEntrypoints) (ToT SwapStorage)
-swapsContract = $$(embedContractM (inBinFolder "fa2_swap.tz"))
 
 -- Errors
 ----------------------------------------------------------------------------
@@ -124,18 +115,18 @@ errSwapOfferedFA2Invalid = [mt|SWAP_OFFERED_FA2_INVALID|]
 errSwapRequestedFA2Invalid :: MText
 errSwapRequestedFA2Invalid = [mt|SWAP_REQUESTED_FA2_INVALID|]
 
-errSwapRequestedFA2BalanceInvalid :: Natural -> Natural -> (MText, Natural, Natural) 
+errSwapRequestedFA2BalanceInvalid :: Natural -> Natural -> (MText, Natural, Natural)
 errSwapRequestedFA2BalanceInvalid requested actual = ([mt|FA2_INSUFFICIENT_BALANCE|], requested, actual)
 
 -- Helpers
 ----------------------------------------------------------------------------
- 
-mkNOffers :: Natural -> SwapOffer -> SwapOffers 
-mkNOffers n s = SwapOffers 
+
+mkNOffers :: Natural -> SwapOffer -> SwapOffers
+mkNOffers n s = SwapOffers
   {
     swapOffer = s
   , remainingOffers = n
   }
 
-mkSingleOffer :: SwapOffer -> SwapOffers 
+mkSingleOffer :: SwapOffer -> SwapOffers
 mkSingleOffer = mkNOffers 1

--- a/packages/minter-contracts/src-hs/Lorentz/Contracts/Swaps/Burn.hs
+++ b/packages/minter-contracts/src-hs/Lorentz/Contracts/Swaps/Burn.hs
@@ -3,12 +3,8 @@ module Lorentz.Contracts.Swaps.Burn where
 
 import Lorentz
 
-import Lorentz.Contracts.MinterSdk
-import Michelson.Test.Import (embedContractM)
-import qualified Michelson.Typed as T
-
-import Tezos.Address (unsafeParseAddress)
 import Lorentz.Contracts.NonPausableSimpleAdmin
+import Tezos.Address (unsafeParseAddress)
 
 import Lorentz.Contracts.Swaps.Allowlisted
 import Lorentz.Contracts.Swaps.Basic
@@ -26,10 +22,10 @@ customGeneric "BurnSwapStorage" ligoLayout
 deriving anyclass instance IsoValue BurnSwapStorage
 deriving anyclass instance HasAnnotation BurnSwapStorage
 
-nullAddress :: Address 
+nullAddress :: Address
 nullAddress = unsafeParseAddress "tz1Ke2h7sDdakHJQh8WX4Z372du1KChsksyU"
 
-altBurnAddress :: Address 
+altBurnAddress :: Address
 altBurnAddress = unsafeParseAddress "tz1burnburnburnburnburnburnburjAYjjX"
 
 initBurnSwapStorage :: BurnSwapStorage
@@ -68,7 +64,8 @@ deriving anyclass instance HasAnnotation AllowlistedBurnSwapEntrypoints
 instance ParameterHasEntrypoints AllowlistedBurnSwapEntrypoints where
   type ParameterEntrypointsDerivation AllowlistedBurnSwapEntrypoints = EpdDelegate
 
--- Used for testing 
+
+-- Used for testing
 data ChangeBurnAddressSwapEntrypoints
   = Swap' SwapEntrypoints
   | Admin' AdminEntrypoints
@@ -81,16 +78,3 @@ deriving anyclass instance HasAnnotation ChangeBurnAddressSwapEntrypoints
 
 instance ParameterHasEntrypoints ChangeBurnAddressSwapEntrypoints where
   type ParameterEntrypointsDerivation ChangeBurnAddressSwapEntrypoints = EpdDelegate
-
--- Contract
-----------------------------------------------------------------------------
-
-allowlistedBurnSwapsContract
-  :: T.Contract (ToT AllowlistedBurnSwapEntrypoints) (ToT AllowlistedBurnSwapStorage)
-allowlistedBurnSwapsContract =
-  $$(embedContractM (inBinFolder "fa2_allowlisted_swap_with_burn.tz"))
-
-changeBurnAddressSwapsContract
-  :: T.Contract (ToT ChangeBurnAddressSwapEntrypoints) (ToT AllowlistedBurnSwapStorage)
-changeBurnAddressSwapsContract =
-  $$(embedContractM (inBinFolder "fa2_allowlisted_swap_with_change_burn_address.tz"))

--- a/packages/minter-contracts/src-hs/Lorentz/Contracts/Swaps/Collections.hs
+++ b/packages/minter-contracts/src-hs/Lorentz/Contracts/Swaps/Collections.hs
@@ -3,13 +3,10 @@ module Lorentz.Contracts.Swaps.Collections where
 
 import Lorentz
 
-import Lorentz.Contracts.MinterSdk
-import Michelson.Test.Import (embedContractM)
-import qualified Michelson.Typed as T
-
-import Lorentz.Contracts.Spec.FA2Interface (TokenId(..))
 import Lorentz.Contracts.NonPausableSimpleAdmin
-import Lorentz.Contracts.Swaps.Basic hiding (mkSingleOffer, mkNOffers, SwapOffer, SwapOffers, SwapInfo)
+import Lorentz.Contracts.Spec.FA2Interface (TokenId(..))
+import Lorentz.Contracts.Swaps.Basic hiding
+  (SwapInfo, SwapOffer, SwapOffers, mkNOffers, mkSingleOffer)
 import Tezos.Address (unsafeParseAddress)
 -- Types
 ----------------------------------------------------------------------------
@@ -45,13 +42,13 @@ customGeneric "SwapInfo" ligoCombLayout
 deriving anyclass instance IsoValue SwapInfo
 deriving anyclass instance HasAnnotation SwapInfo
 
-incrementCollectionId :: CollectionId -> CollectionId 
+incrementCollectionId :: CollectionId -> CollectionId
 incrementCollectionId (CollectionId n) = CollectionId (n + 1)
 
 initCollectionId :: CollectionId
 initCollectionId = CollectionId 1
 
-getCollectionId :: CollectionId -> Natural 
+getCollectionId :: CollectionId -> Natural
 getCollectionId (CollectionId n) = n
 
 data Permit = Permit
@@ -63,10 +60,10 @@ customGeneric "Permit" ligoCombLayout
 deriving anyclass instance IsoValue Permit
 deriving anyclass instance HasAnnotation Permit
 
-nullAddress :: Address 
+nullAddress :: Address
 nullAddress = unsafeParseAddress "tz1Ke2h7sDdakHJQh8WX4Z372du1KChsksyU"
 
-exampleFA2Address :: Address 
+exampleFA2Address :: Address
 exampleFA2Address = unsafeParseAddress "KT1T7ShxhtSRuhvhHeug6Sjc7W8irLmswEt7"
 
 data CollectionsStorage = CollectionsStorage
@@ -89,13 +86,13 @@ initCollectionsStorage admin fa2Address = CollectionsStorage
   , nextCollectionId = initCollectionId
   , swaps = mempty
   , burnAddress = nullAddress
-  , collections = mempty 
+  , collections = mempty
   , fa2Address = fa2Address
-  , admin = initAdminStorage admin 
+  , admin = initAdminStorage admin
   }
 
-data AcceptParam = AcceptParam 
-  { swapId :: SwapId , 
+data AcceptParam = AcceptParam
+  { swapId :: SwapId ,
     tokensSent :: Set (CollectionId, TokenId)
   }
 
@@ -107,7 +104,7 @@ data CollectionsEntrypoints
   = Start SwapOffers
   | Cancel SwapId
   | Accept AcceptParam
-  | Add_collection (Set TokenId) 
+  | Add_collection (Set TokenId)
   | Admin AdminEntrypoints
 
 customGeneric "CollectionsEntrypoints" ligoLayout
@@ -137,20 +134,6 @@ deriving anyclass instance HasAnnotation OffchainCollectionsEntrypoints
 instance ParameterHasEntrypoints OffchainCollectionsEntrypoints where
   type ParameterEntrypointsDerivation OffchainCollectionsEntrypoints = EpdDelegate
 
--- Contract
-----------------------------------------------------------------------------
-
-collectionsContract
-  :: T.Contract (ToT CollectionsEntrypoints) (ToT CollectionsStorage)
-collectionsContract =
-  $$(embedContractM (inBinFolder "fa2_swap_with_collections_and_burn.tz"))
-
-offchainCollectionsContract
-  :: T.Contract (ToT OffchainCollectionsEntrypoints) (ToT CollectionsStorage)
-offchainCollectionsContract =
-  $$(embedContractM (inBinFolder "fa2_swap_with_collections_and_burn_offchain.tz"))
-
-
 -- Errors
 ----------------------------------------------------------------------------
 errSwapNotExist :: MText
@@ -172,7 +155,7 @@ errSwapRequestedFA2Invalid = [mt|SWAP_REQUESTED_FA2_INVALID|]
 errTokensSentInvalid :: MText
 errTokensSentInvalid = [mt|TOKENS_SENT_INVALID|]
 
-errSwapRequestedFA2BalanceInvalid :: Natural -> Natural -> (MText, Natural, Natural) 
+errSwapRequestedFA2BalanceInvalid :: Natural -> Natural -> (MText, Natural, Natural)
 errSwapRequestedFA2BalanceInvalid requested actual = ([mt|FA2_INSUFFICIENT_BALANCE|], requested, actual)
 
 errNotAdmin :: MText
@@ -180,13 +163,13 @@ errNotAdmin = [mt|NOT_AN_ADMIN|]
 
 -- Helpers
 ----------------------------------------------------------------------------
- 
-mkNOffers :: Natural -> SwapOffer -> SwapOffers 
-mkNOffers n s = SwapOffers 
+
+mkNOffers :: Natural -> SwapOffer -> SwapOffers
+mkNOffers n s = SwapOffers
   {
     swapOffer = s
   , remainingOffers = n
   }
 
-mkSingleOffer :: SwapOffer -> SwapOffers 
+mkSingleOffer :: SwapOffer -> SwapOffers
 mkSingleOffer = mkNOffers 1

--- a/packages/minter-contracts/src-hs/Lorentz/Contracts/Swaps/Contracts.hs
+++ b/packages/minter-contracts/src-hs/Lorentz/Contracts/Swaps/Contracts.hs
@@ -1,0 +1,63 @@
+-- | Lorentz swap contracts.
+module Lorentz.Contracts.Swaps.Contracts where
+
+import Lorentz
+import Lorentz.Test.Import (embedContractM)
+
+import Lorentz.Contracts.MinterSdk
+
+import Lorentz.Contracts.Swaps.Allowlisted
+import Lorentz.Contracts.Swaps.Basic
+import Lorentz.Contracts.Swaps.SwapPermit
+
+import qualified Lorentz.Contracts.Swaps.AllowlistedFee as AllowlistedFee
+import Lorentz.Contracts.Swaps.Burn
+
+import Lorentz.Contracts.Swaps.Collections
+import Lorentz.Contracts.Swaps.SwapPermitBurnFee
+
+swapsContract :: Contract SwapEntrypoints SwapStorage
+swapsContract =
+  $$(embedContractM (inBinFolder "fa2_swap.tz"))
+
+allowlistedSwapsContract
+  :: Contract AllowlistedSwapEntrypoints AllowlistedSwapStorage
+allowlistedSwapsContract =
+  $$(embedContractM (inBinFolder "fa2_allowlisted_swap.tz"))
+
+allowlistedBurnSwapsContract
+  :: Contract AllowlistedBurnSwapEntrypoints AllowlistedBurnSwapStorage
+allowlistedBurnSwapsContract =
+  $$(embedContractM (inBinFolder "fa2_allowlisted_swap_with_burn.tz"))
+
+changeBurnAddressSwapsContract
+  :: Contract ChangeBurnAddressSwapEntrypoints AllowlistedBurnSwapStorage
+changeBurnAddressSwapsContract =
+  $$(embedContractM (inBinFolder "fa2_allowlisted_swap_with_change_burn_address.tz"))
+
+allowlistedSwapsPermitContract
+  :: Contract PermitSwapEntrypoints AllowlistedSwapStorage
+allowlistedSwapsPermitContract =
+  $$(embedContractM (inBinFolder "fa2_allowlisted_swap_offchain_nocounter.tz"))
+
+allowlistedFeeSwapsContract
+  :: Contract
+       AllowlistedFee.AllowlistedFeeSwapEntrypoints
+       AllowlistedFee.AllowlistedFeeSwapStorage
+allowlistedFeeSwapsContract =
+  $$(embedContractM (inBinFolder "fa2_fee_allowlisted_swap.tz"))
+
+allowlistedSwapsPermitBurnFeeContract
+  :: Contract PermitSwapBurnFeeEntrypoints AllowlistedBurnSwapFeeStorage
+allowlistedSwapsPermitBurnFeeContract =
+  $$(embedContractM (inBinFolder "fa2_swap_offchain_burn_fee.tz"))
+
+collectionsContract
+  :: Contract CollectionsEntrypoints CollectionsStorage
+collectionsContract =
+  $$(embedContractM (inBinFolder "fa2_swap_with_collections_and_burn.tz"))
+
+offchainCollectionsContract
+  :: Contract OffchainCollectionsEntrypoints CollectionsStorage
+offchainCollectionsContract =
+  $$(embedContractM (inBinFolder "fa2_swap_with_collections_and_burn_offchain.tz"))

--- a/packages/minter-contracts/src-hs/Lorentz/Contracts/Swaps/SwapPermit.hs
+++ b/packages/minter-contracts/src-hs/Lorentz/Contracts/Swaps/SwapPermit.hs
@@ -3,10 +3,6 @@ module Lorentz.Contracts.Swaps.SwapPermit where
 
 import Lorentz
 
-import Lorentz.Contracts.MinterSdk
-import Michelson.Test.Import (embedContractM)
-import qualified Michelson.Typed as T
-
 import Lorentz.Contracts.Swaps.Allowlisted
 -- Types
 ----------------------------------------------------------------------------
@@ -21,7 +17,7 @@ deriving anyclass instance IsoValue Permit
 deriving anyclass instance HasAnnotation Permit
 
 data OffchainAcceptParam = OffchainAcceptParam
-  { swapId :: Natural 
+  { swapId :: Natural
   , permit :: Permit
   }
 
@@ -39,14 +35,6 @@ deriving anyclass instance HasAnnotation PermitSwapEntrypoints
 
 instance ParameterHasEntrypoints PermitSwapEntrypoints where
   type ParameterEntrypointsDerivation PermitSwapEntrypoints = EpdDelegate
-
--- Contract
-----------------------------------------------------------------------------
-
-allowlistedSwapsPermitContract
-  :: T.Contract (ToT PermitSwapEntrypoints) (ToT AllowlistedSwapStorage)
-allowlistedSwapsPermitContract =
-  $$(embedContractM (inBinFolder "fa2_allowlisted_swap_offchain_nocounter.tz"))
 
 -- Errors
 ----------------------------------------------------------------------------

--- a/packages/minter-contracts/src-hs/Lorentz/Contracts/Swaps/SwapPermitBurnFee.hs
+++ b/packages/minter-contracts/src-hs/Lorentz/Contracts/Swaps/SwapPermitBurnFee.hs
@@ -3,15 +3,11 @@ module Lorentz.Contracts.Swaps.SwapPermitBurnFee where
 
 import Lorentz
 
-import Lorentz.Contracts.MinterSdk
-import Michelson.Test.Import (embedContractM)
-import qualified Michelson.Typed as T
-
 import Lorentz.Contracts.NonPausableSimpleAdmin
+import Lorentz.Contracts.Swaps.AllowlistedFee as AllowlistedFee
 import Lorentz.Contracts.Swaps.Basic
 import Lorentz.Contracts.Swaps.Burn
 import Lorentz.Contracts.Swaps.SwapPermit
-import Lorentz.Contracts.Swaps.AllowlistedFee as AllowlistedFee 
 -- Types
 ----------------------------------------------------------------------------
 
@@ -59,14 +55,6 @@ deriving anyclass instance HasAnnotation PermitSwapBurnFeeEntrypoints
 
 instance ParameterHasEntrypoints PermitSwapBurnFeeEntrypoints where
   type ParameterEntrypointsDerivation PermitSwapBurnFeeEntrypoints = EpdDelegate
-
--- Contract
-----------------------------------------------------------------------------
-
-allowlistedSwapsPermitBurnFeeContract
-  :: T.Contract (ToT PermitSwapBurnFeeEntrypoints) (ToT AllowlistedBurnSwapFeeStorage)
-allowlistedSwapsPermitBurnFeeContract =
-  $$(embedContractM (inBinFolder "fa2_swap_offchain_burn_fee.tz"))
 
 -- Errors
 ----------------------------------------------------------------------------

--- a/packages/minter-contracts/stack.yaml
+++ b/packages/minter-contracts/stack.yaml
@@ -20,7 +20,7 @@ extra-deps:
 - git:
     https://gitlab.com/morley-framework/morley.git
   commit:
-    5fe2d892b64ac22aa29b6c2c07d19bd4c475c210  # master
+    439239cc921fcf0bf90490eaffb03eb01bc9f7d1  # master
   subdirs:
     - code/morley
     - code/lorentz
@@ -30,12 +30,12 @@ extra-deps:
 - git:
     https://gitlab.com/morley-framework/indigo.git
   commit:
-    1177ddb1390610c76b8a735c1fda2eacb2cbef6b  # master
+    4ba66d2976c06d10b4686083ee25234106846504  # master
   subdirs:
     - .
 
 - git: https://gitlab.com/morley-framework/morley-ledgers.git
-  commit: 8e1ec4c161ee9c22e03c74dccb579634ced6165c  # master
+  commit: 93792e47ac0373951ab927f7f0a446981d83a3f5  # master
   subdirs:
     - code/morley-ledgers
 
@@ -51,7 +51,7 @@ extra-deps:
   commit: c5d61837eb358989b581ed82b1e79158c4823b1b
 
 - hex-text-0.1.0.2@sha256:154df2b81c1dd38b055fa6a90cb6964f60c5cf4a0ba633ea929d8a79af89519a,1301
-- morley-prelude-0.4.0
+- morley-prelude-0.4.1
 - named-0.3.0.1@sha256:2975d50c9c5d88095026ffc1303d2d9be52e5f588a8f8bcb7003a04b79f10a06,2312
 - show-type-0.1.1@sha256:24f681a3481b3f9630e619d816054804ba1bd6cc05b5978ddd2cece8499ff2fa,1154
 - base16-bytestring-1.0.1.0@sha256:33b9d57afa334d06485033e930c6b13fc760baf88fd8f715ae2f9a4b46e19a54

--- a/packages/minter-contracts/stack.yaml.lock
+++ b/packages/minter-contracts/stack.yaml.lock
@@ -10,78 +10,78 @@ packages:
     version: 1.14.0
     git: https://gitlab.com/morley-framework/morley.git
     pantry-tree:
-      size: 9641
-      sha256: 721e612078b98eefbf4ccd39705f64238590e3605103cc9ccbb1cfd3eeafc895
-    commit: 5fe2d892b64ac22aa29b6c2c07d19bd4c475c210
+      size: 9854
+      sha256: 94cc944145522572fdf6a358fef9ad178f99ac552cc776d89a2c2bf86dfe26ca
+    commit: 439239cc921fcf0bf90490eaffb03eb01bc9f7d1
   original:
     subdir: code/morley
     git: https://gitlab.com/morley-framework/morley.git
-    commit: 5fe2d892b64ac22aa29b6c2c07d19bd4c475c210
+    commit: 439239cc921fcf0bf90490eaffb03eb01bc9f7d1
 - completed:
     subdir: code/lorentz
     name: lorentz
     version: 0.11.0
     git: https://gitlab.com/morley-framework/morley.git
     pantry-tree:
-      size: 3872
-      sha256: aa52570569e2d1357ac16984eb0621a1ed64ce6bb72b6a84c6482d3556e01449
-    commit: 5fe2d892b64ac22aa29b6c2c07d19bd4c475c210
+      size: 3873
+      sha256: 3f2d65d1a79d90810bcd13cbd2e236a882e112a08d6bd9e7dbde6b0fdcf685fd
+    commit: 439239cc921fcf0bf90490eaffb03eb01bc9f7d1
   original:
     subdir: code/lorentz
     git: https://gitlab.com/morley-framework/morley.git
-    commit: 5fe2d892b64ac22aa29b6c2c07d19bd4c475c210
+    commit: 439239cc921fcf0bf90490eaffb03eb01bc9f7d1
 - completed:
     subdir: code/cleveland
     name: cleveland
     version: 0.1.0
     git: https://gitlab.com/morley-framework/morley.git
     pantry-tree:
-      size: 13030
-      sha256: 8ae2de78151c5a70c4f40fe8b9688c8294fed89e30276bebaaf6003068087987
-    commit: 5fe2d892b64ac22aa29b6c2c07d19bd4c475c210
+      size: 13196
+      sha256: ab6359d9e7edd00ec58c1f5cfb3beb2e03a2f857aa3a51ca55adad849f9828e6
+    commit: 439239cc921fcf0bf90490eaffb03eb01bc9f7d1
   original:
     subdir: code/cleveland
     git: https://gitlab.com/morley-framework/morley.git
-    commit: 5fe2d892b64ac22aa29b6c2c07d19bd4c475c210
+    commit: 439239cc921fcf0bf90490eaffb03eb01bc9f7d1
 - completed:
     subdir: code/morley-client
     name: morley-client
     version: 0.1.0
     git: https://gitlab.com/morley-framework/morley.git
     pantry-tree:
-      size: 3312
-      sha256: c6c5b50629ae8eefda0913141ee5c6225f753e578a5f8e659cb0cc4db38d21c7
-    commit: 5fe2d892b64ac22aa29b6c2c07d19bd4c475c210
+      size: 3313
+      sha256: 8024fe91667b551cd1510bc546f98698f8847ef54b54c866733706ee76d5d0e1
+    commit: 439239cc921fcf0bf90490eaffb03eb01bc9f7d1
   original:
     subdir: code/morley-client
     git: https://gitlab.com/morley-framework/morley.git
-    commit: 5fe2d892b64ac22aa29b6c2c07d19bd4c475c210
+    commit: 439239cc921fcf0bf90490eaffb03eb01bc9f7d1
 - completed:
     subdir: .
     name: indigo
     version: 0.5.0
     git: https://gitlab.com/morley-framework/indigo.git
     pantry-tree:
-      size: 14289
-      sha256: ef99aad2d1e78d11dbfec854ed368624367efa8edbb9ca13c0f7e9b7c3e53271
-    commit: 1177ddb1390610c76b8a735c1fda2eacb2cbef6b
+      size: 14358
+      sha256: 70c062eeb6999aad27e89a1d10b7f6ffb4f319d992c996a7979722036482d6da
+    commit: 4ba66d2976c06d10b4686083ee25234106846504
   original:
     subdir: .
     git: https://gitlab.com/morley-framework/indigo.git
-    commit: 1177ddb1390610c76b8a735c1fda2eacb2cbef6b
+    commit: 4ba66d2976c06d10b4686083ee25234106846504
 - completed:
     subdir: code/morley-ledgers
     name: morley-ledgers
     version: 0.2.0.1
     git: https://gitlab.com/morley-framework/morley-ledgers.git
     pantry-tree:
-      size: 1524
-      sha256: 954ab3e15182915ba802def3b81ac5607adca5e5b33054942e4434cbdf1e1a53
-    commit: 8e1ec4c161ee9c22e03c74dccb579634ced6165c
+      size: 1525
+      sha256: 77b8b3a7378839a523070f91de1008226dd7afc5cdff6d463eaeeccc29de7fcb
+    commit: 93792e47ac0373951ab927f7f0a446981d83a3f5
   original:
     subdir: code/morley-ledgers
     git: https://gitlab.com/morley-framework/morley-ledgers.git
-    commit: 8e1ec4c161ee9c22e03c74dccb579634ced6165c
+    commit: 93792e47ac0373951ab927f7f0a446981d83a3f5
 - completed:
     name: base-noprelude
     version: 4.14.1.0
@@ -145,12 +145,12 @@ packages:
   original:
     hackage: hex-text-0.1.0.2@sha256:154df2b81c1dd38b055fa6a90cb6964f60c5cf4a0ba633ea929d8a79af89519a,1301
 - completed:
-    hackage: morley-prelude-0.4.0@sha256:7234db1acac9a5554d01bdbf22d63b598c69b9fefaeace0fb6f765bf7bf738d4,2176
+    hackage: morley-prelude-0.4.1@sha256:e2446405985f3248576a785d274f00eb16a2f1cfb0b123ade0206da345081f7b,2187
     pantry-tree:
       size: 269
-      sha256: 5ef63d068139d79b4bd5832822447ee0a9313da368c70245a79b13e1bc44a2dd
+      sha256: cd19c52a38ec8e23d138ba7ada5d50fee78e9ec922cade0eda29a730fcf6fc3a
   original:
-    hackage: morley-prelude-0.4.0
+    hackage: morley-prelude-0.4.1
 - completed:
     hackage: named-0.3.0.1@sha256:2975d50c9c5d88095026ffc1303d2d9be52e5f588a8f8bcb7003a04b79f10a06,2312
     pantry-tree:

--- a/packages/minter-contracts/test-hs/Test/EnglishAuction/Util.hs
+++ b/packages/minter-contracts/test-hs/Test/EnglishAuction/Util.hs
@@ -10,11 +10,11 @@ module Test.EnglishAuction.Util
   ) where
 
 import Lorentz.Value
-import qualified Michelson.Typed as T
 import Morley.Nettest
 
 import Lorentz.Contracts.AllowlistSimple as AllowlistSimple
 import Lorentz.Contracts.AllowlistToken as AllowlistToken
+import Lorentz.Contracts.EnglishAuction.Contracts
 import qualified Lorentz.Contracts.EnglishAuction.FA2 as AuctionFA2
 import qualified Lorentz.Contracts.EnglishAuction.Tez as AuctionTez
 import qualified Lorentz.Contracts.EnglishAuction.TezPermit as AuctionPermitTez
@@ -24,70 +24,74 @@ originateAuctionFA2Allowlisted
   :: MonadNettest caps base m
   => AuctionFA2.BidCurrency
   -> Address
-  -> m (TAddress $ AuctionFA2.AuctionEntrypoints AllowlistSimple.Entrypoints)
-originateAuctionFA2Allowlisted bidCurrency admin = do
-  TAddress <$> originateUntypedSimple "auction-fa2"
-    (T.untypeValue $ T.toVal $
-      AuctionFA2.initAuctionStorage @AllowlistSimple.Allowlist
-        (PausableAdminOption.initAdminStorage admin)
-        bidCurrency
+  -> m $ ContractHandler
+       (AuctionFA2.AuctionEntrypoints AllowlistSimple.Entrypoints)
+       (AuctionFA2.AuctionStorage AllowlistSimple.Allowlist)
+originateAuctionFA2Allowlisted bidCurrency admin =
+  originateSimple "auction-fa2"
+    (AuctionFA2.initAuctionStorage
+      (PausableAdminOption.initAdminStorage admin)
+      bidCurrency
     )
-    (T.convertContract AuctionFA2.auctionFA2AllowlistedContract)
+    auctionFA2AllowlistedContract
 
 originateAuctionFA2AllowlistedToken
   :: MonadNettest caps base m
   => AuctionFA2.BidCurrency
   -> Address
-  -> m (TAddress $ AuctionFA2.AuctionEntrypoints AllowlistToken.Entrypoints)
+  -> m $ ContractHandler
+        (AuctionFA2.AuctionEntrypoints AllowlistToken.Entrypoints)
+        (AuctionFA2.AuctionStorage AllowlistToken.Allowlist)
 originateAuctionFA2AllowlistedToken bidCurrency admin = do
-  TAddress <$> originateUntypedSimple "auction-fa2"
-    (T.untypeValue $ T.toVal $
-      AuctionFA2.initAuctionStorage @AllowlistToken.Allowlist
-        (PausableAdminOption.initAdminStorage admin)
-        bidCurrency
+  originateSimple "auction-fa2"
+    (AuctionFA2.initAuctionStorage
+      (PausableAdminOption.initAdminStorage admin)
+      bidCurrency
     )
-    (T.convertContract AuctionFA2.auctionFA2AllowlistedTokenContract)
+    auctionFA2AllowlistedTokenContract
 
 originateAuctionTezAllowlisted
   :: MonadNettest caps base m
   => Address
-  -> m (TAddress $ AuctionTez.AuctionEntrypoints AllowlistSimple.Entrypoints)
+  -> m $ ContractHandler
+        (AuctionTez.AuctionEntrypoints AllowlistSimple.Entrypoints)
+        (AuctionTez.AuctionStorage AllowlistSimple.Allowlist)
 originateAuctionTezAllowlisted admin = do
-  TAddress <$> originateUntypedSimple "auction-tez"
-    (T.untypeValue $ T.toVal $
-      AuctionTez.initAuctionStorage @AllowlistSimple.Allowlist
-        (PausableAdminOption.initAdminStorage admin))
-    (T.convertContract AuctionTez.auctionTezAllowlistedContract)
+  originateSimple "auction-tez"
+    (AuctionTez.initAuctionStorage (PausableAdminOption.initAdminStorage admin))
+    auctionTezAllowlistedContract
 
 originateAuctionTezAllowlistedToken
   :: MonadNettest caps base m
   => Address
-  -> m (TAddress $ AuctionTez.AuctionEntrypoints AllowlistToken.Entrypoints)
+  -> m $ ContractHandler
+        (AuctionTez.AuctionEntrypoints AllowlistToken.Entrypoints)
+        (AuctionTez.AuctionStorage AllowlistToken.Allowlist)
 originateAuctionTezAllowlistedToken admin = do
-  TAddress <$> originateUntypedSimple "auction-tez"
-    (T.untypeValue $ T.toVal $
-      AuctionTez.initAuctionStorage @AllowlistToken.Allowlist
-        (PausableAdminOption.initAdminStorage admin))
-    (T.convertContract AuctionTez.auctionTezAllowlistedTokenContract)
+  originateSimple "auction-tez"
+    (AuctionTez.initAuctionStorage (PausableAdminOption.initAdminStorage admin))
+    auctionTezAllowlistedTokenContract
 
 originateAuctionTezPermitAllowlisted
   :: MonadNettest caps base m
   => Address
-  -> m (TAddress $ AuctionPermitTez.PermitAuctionEntrypoints AllowlistSimple.Entrypoints)
+  -> m $ ContractHandler
+        (AuctionPermitTez.PermitAuctionEntrypoints AllowlistSimple.Entrypoints)
+        (AuctionPermitTez.PermitAuctionStorage AllowlistSimple.Allowlist)
 originateAuctionTezPermitAllowlisted admin = do
-  TAddress <$> originateUntypedSimple "auction-permit-tez"
-    (T.untypeValue $ T.toVal $
-      AuctionPermitTez.initPermitAuctionStorage @AllowlistSimple.Allowlist
-        (PausableAdminOption.initAdminStorage admin))
-    (T.convertContract AuctionPermitTez.auctionTezPermitAllowlistedContract)
+  originateSimple "auction-permit-tez"
+    (AuctionPermitTez.initPermitAuctionStorage
+       (PausableAdminOption.initAdminStorage admin))
+    auctionTezPermitAllowlistedContract
 
 originateAuctionTezPermitAllowlistedToken
   :: MonadNettest caps base m
   => Address
-  -> m (TAddress $ AuctionPermitTez.PermitAuctionEntrypoints AllowlistToken.Entrypoints)
+  -> m $ ContractHandler
+        (AuctionPermitTez.PermitAuctionEntrypoints AllowlistToken.Entrypoints)
+        (AuctionPermitTez.PermitAuctionStorage AllowlistToken.Allowlist)
 originateAuctionTezPermitAllowlistedToken admin = do
-  TAddress <$> originateUntypedSimple "auction-permit-tez"
-    (T.untypeValue $ T.toVal $
-      AuctionPermitTez.initPermitAuctionStorage @AllowlistToken.Allowlist
-        (PausableAdminOption.initAdminStorage admin))
-    (T.convertContract AuctionPermitTez.auctionTezPermitAllowlistedTokenContract)
+  originateSimple "auction-permit-tez"
+    (AuctionPermitTez.initPermitAuctionStorage
+      (PausableAdminOption.initAdminStorage admin))
+    auctionTezPermitAllowlistedTokenContract

--- a/packages/minter-contracts/test-hs/Test/Marketplace/TezOffchain.hs
+++ b/packages/minter-contracts/test-hs/Test/Marketplace/TezOffchain.hs
@@ -1,22 +1,21 @@
 module Test.Marketplace.TezOffchain where
 
+import Data.Int ()
+import Data.List ()
 import qualified Data.Map as Map
-import Data.List()
-import Data.Set as Set 
-import Data.Int()
+import Data.Set as Set
 
 import Hedgehog (Gen, Property, forAll, property)
 import qualified Hedgehog.Gen as Gen
 import qualified Hedgehog.Range as Range
 import Morley.Nettest
 
+import Hedgehog.Gen.Tezos.Core (genMutez')
+import qualified Indigo.Contracts.FA2Sample as FA2
 import Lorentz hiding (balance, contract)
-import Michelson.Typed (convertContract, untypeValue)
 import Michelson.Interpret.Pack
 
-import Morley.Client.TezosClient.Types
-import qualified Indigo.Contracts.FA2Sample as FA2
-
+import Lorentz.Contracts.Marketplace.Contracts
 import Lorentz.Contracts.Marketplace.Tez
 import Lorentz.Contracts.Marketplace.TezOffchain
 
@@ -58,7 +57,7 @@ hprop_Assets_are_transferred_to_buyer_after_confirm  =
           offchainBuy buyer n contract
           confirmPurchase buyer contract
           buyerAssetBalance <- balanceOf assetFA2 assetTokenId buyer
-          buyerAssetBalance @== n 
+          buyerAssetBalance @== n
 
       sellerAssetBalance <- balanceOf assetFA2 assetTokenId seller
       sellerAssetBalance @== 0
@@ -71,7 +70,7 @@ hprop_Assets_are_not_transferred_to_buyer_after_offchain_buy  =
       setup@Setup{seller, buyer, assetFA2} <- testSetup testData
       contract <- originateOffchainTezMarketplaceContract setup
 
-      withSender seller $ do 
+      withSender seller $ do
         sell testData setup contract
         offchainBuy buyer 1 contract
         buyerAssetBalance <- balanceOf assetFA2 assetTokenId buyer
@@ -91,8 +90,8 @@ hprop_Cant_offchain_buy_more_assets_than_are_available =
       withSender seller $ do
         sell testData setup contract
         offchainBuyAll testData setup contract
-        offchainBuy buyer (testTokenAmount + 1) contract `expectFailure`
-          failedWith contract [mt|NO_SALE|]
+        offchainBuy buyer (testTokenAmount + 1) contract
+          & expectTransferFailure [failedWith $ constant [mt|NO_SALE|]]
 
 hprop_Cant_buy_with_tez_after_all_assets_are_reserved_through_offchain_buy :: Property
 hprop_Cant_buy_with_tez_after_all_assets_are_reserved_through_offchain_buy =
@@ -100,18 +99,19 @@ hprop_Cant_buy_with_tez_after_all_assets_are_reserved_through_offchain_buy =
     testData@TestData{testTokenAmount} <- forAll genTestData
 
     clevelandProp $ do
-      setup@Setup{seller, buyer, assetFA2} <- testSetup testData
+      setup@Setup{seller, buyer} <- testSetup testData
       contract <- originateOffchainTezMarketplaceContract setup
 
       withSender seller $ do
         sell testData setup contract
         offchainBuyAll testData setup contract
-      
-      withSender buyer $ do 
-        buy testData contract `expectFailure`
+
+      withSender buyer $ do
+        buy testData contract
+          & expectTransferFailure
           if testTokenAmount == 0
-            then failedWith assetFA2 ([mt|FA2_INSUFFICIENT_BALANCE|], 1 :: Natural, 0 :: Natural)
-            else failedWith contract [mt|NO_SALE|]
+            then [failedWith $ constant ([mt|FA2_INSUFFICIENT_BALANCE|], 1 :: Natural, 0 :: Natural)]
+            else [failedWith $ constant [mt|NO_SALE|]]
 
 hprop_Offchain_buy_and_confirm_equals_buy :: Property
 hprop_Offchain_buy_and_confirm_equals_buy =
@@ -129,32 +129,26 @@ hprop_Offchain_buy_and_confirm_equals_buy =
       withSender seller2 $
         sell testData setup2 contract2
 
-      withSender seller1 $ 
+      withSender seller1 $
         offchainBuyAll testData setup1 contract1
 
-      withSender buyer2 $ 
+      withSender buyer2 $
         buyAll testData contract2
-      
+
       buyerAssetBalance1 <- balanceOf assetFA2V1 assetTokenId buyer1
       contractAssetBalance1 <- balanceOf assetFA2V1 assetTokenId contract1
       sellerAssetBalance1 <- balanceOf assetFA2V1 assetTokenId seller1
-      
+
       buyerAssetBalance2 <- balanceOf assetFA2V2 assetTokenId buyer2
       contractAssetBalance2 <- balanceOf assetFA2V2 assetTokenId contract2
       sellerAssetBalance2 <- balanceOf assetFA2V2 assetTokenId seller2
 
-      marketplaceStorage1 <- toVal <$>
-                             marketplaceStorage <$>
-                             fromVal @(MarketplaceTezOffchainStorage ()) <$> 
-                             getStorage' contract1
-      marketplaceStorage2 <- toVal <$>
-                             marketplaceStorage <$>
-                             fromVal @(MarketplaceTezOffchainStorage ()) <$> 
-                             getStorage' contract2
-                             
+      marketplaceStorage1 <- toVal . marketplaceStorage <$> getStorage' contract1
+      marketplaceStorage2 <- toVal . marketplaceStorage <$> getStorage' contract2
+
       marketplaceStorage1 @== marketplaceStorage2
       buyerAssetBalance1 @== buyerAssetBalance2
-      contractAssetBalance1 @== contractAssetBalance2 
+      contractAssetBalance1 @== contractAssetBalance2
       sellerAssetBalance1 @== sellerAssetBalance2
 
 hprop_Offchain_buy_and_revoke_equals_do_nothing :: Property
@@ -168,29 +162,27 @@ hprop_Offchain_buy_and_revoke_equals_do_nothing =
 
       withSender seller $ do
         sell testData setup contract
-      
+
       buyerAssetBalanceInit <- balanceOf assetFA2 assetTokenId buyer
       contractAssetBalanceInit <- balanceOf assetFA2 assetTokenId contract
       sellerAssetBalanceInit <- balanceOf assetFA2 assetTokenId seller
       marketplaceStorageInit <- toVal <$>
                           marketplaceStorage <$>
-                          fromVal @(MarketplaceTezOffchainStorage ()) <$> 
                           getStorage' contract
 
       withSender seller $ do
         offchainBuy buyer 1 contract
-        revokePurchase buyer contract 
+        revokePurchase buyer contract
 
       buyerAssetBalanceFinal <- balanceOf assetFA2 assetTokenId buyer
       contractAssetBalanceFinal  <- balanceOf assetFA2 assetTokenId contract
       sellerAssetBalanceFinal  <- balanceOf assetFA2 assetTokenId seller
       marketplaceStorageFinal <- toVal <$>
                                  marketplaceStorage <$>
-                                 fromVal @(MarketplaceTezOffchainStorage ()) <$> 
                                  getStorage' contract
-          
+
       buyerAssetBalanceInit @== buyerAssetBalanceFinal
-      contractAssetBalanceInit @== contractAssetBalanceFinal 
+      contractAssetBalanceInit @== contractAssetBalanceFinal
       sellerAssetBalanceInit @== sellerAssetBalanceFinal
       marketplaceStorageInit @== marketplaceStorageFinal
 
@@ -202,11 +194,12 @@ hprop_Forged_offchain_buy_fails =
       setup@Setup{seller, buyer} <- testSetup testData
       contract <- originateOffchainTezMarketplaceContract setup
 
-      withSender seller $ do 
-        missignedBytes <- fst <$> mkPermitToForge (SaleId 0) 1 contract 
+      withSender seller $ do
+        missignedBytes <- fst <$> mkPermitToForge (SaleId 0) 1 contract
         sell testData setup contract
-        offchainBuyForged buyer 1 contract `expectFailure` failedWith contract 
-          ([mt|MISSIGNED|], missignedBytes)
+        offchainBuyForged buyer 1 contract
+          & expectTransferFailure
+            [failedWith $ constant ([mt|MISSIGNED|], missignedBytes)]
 
 hprop_Cant_offchain_buy_if_purchaser_has_pending_purchase_present :: Property
 hprop_Cant_offchain_buy_if_purchaser_has_pending_purchase_present  =
@@ -218,8 +211,9 @@ hprop_Cant_offchain_buy_if_purchaser_has_pending_purchase_present  =
       contract <- originateOffchainTezMarketplaceContract setup
 
       withSender seller $ do
-        offchainBuy buyer 1 contract `expectFailure`
-          failedWith contract [mt|PENDING_PURCHASE_PRESENT|]
+        offchainBuy buyer 1 contract
+          & expectTransferFailure
+            [failedWith $ constant [mt|PENDING_PURCHASE_PRESENT|]]
   where
   addSaleAndPendingPurcahseToInitialStorage :: TestData -> Setup -> Setup
   addSaleAndPendingPurcahseToInitialStorage TestData{testSalePrice, testTokenAmount} setup@Setup{storage, buyer, seller, assetFA2} =
@@ -238,7 +232,7 @@ hprop_Cant_offchain_buy_if_purchaser_has_pending_purchase_present  =
                      , salePricePerToken = testSalePrice
                      , tokenAmount = testTokenAmount
                      }
-                   , pendingPurchases = Set.singleton buyer 
+                   , pendingPurchases = Set.singleton buyer
                    }
                  )
                ]
@@ -262,15 +256,9 @@ hprop_Consecutive_offchain_buy_equals_iterative_buy =
         sell testData setup2 contract2
         offchainBuyAllConsecutive testData contract1
         offchainBuyAll testData setup2 contract2
-    
-      marketplaceStorage1 <- toVal <$>
-                             marketplaceStorage <$>
-                             fromVal @(MarketplaceTezOffchainStorage ()) <$> 
-                             getStorage' contract1
-      marketplaceStorage2 <- toVal <$>
-                             marketplaceStorage <$>
-                             fromVal @(MarketplaceTezOffchainStorage ()) <$> 
-                             getStorage' contract2
+
+      marketplaceStorage1 <- toVal . marketplaceStorage <$> getStorage' contract1
+      marketplaceStorage2 <- toVal . marketplaceStorage <$> getStorage' contract2
       marketplaceStorage1 @== marketplaceStorage2
 
 hprop_Batch_offchain_buy_equals_consecutive_buy :: Property
@@ -289,15 +277,9 @@ hprop_Batch_offchain_buy_equals_consecutive_buy =
         sell testData setup2 contract2
         offchainBuyAllConsecutive testData contract1
         offchainBuyAllBatch testData contract2
-    
-      marketplaceStorage1 <- toVal <$>
-                             marketplaceStorage <$>
-                             fromVal @(MarketplaceTezOffchainStorage ()) <$> 
-                             getStorage' contract1
-      marketplaceStorage2 <- toVal <$>
-                             marketplaceStorage <$>
-                             fromVal @(MarketplaceTezOffchainStorage ()) <$> 
-                             getStorage' contract2
+
+      marketplaceStorage1 <- toVal . marketplaceStorage <$> getStorage' contract1
+      marketplaceStorage2 <- toVal . marketplaceStorage <$> getStorage' contract2
       marketplaceStorage1 @== marketplaceStorage2
 
 ----------------------------------------------------------------------------
@@ -331,7 +313,7 @@ genTestData = do
 data Setup = Setup
   { seller :: Address
   , buyer :: Address
-  , assetFA2 :: TAddress FA2.FA2SampleParameter
+  , assetFA2 :: ContractHandler FA2.FA2SampleParameter FA2.Storage
   , storage :: MarketplaceTezOffchainStorage ()
   }
 
@@ -360,11 +342,11 @@ testSetup testData = do
 
   pure Setup {..}
 
-originateOffchainTezMarketplaceContract :: MonadNettest caps base m => Setup -> m (TAddress $ MarketplaceTezOffchainEntrypoints ())
+originateOffchainTezMarketplaceContract :: MonadNettest caps base m => Setup -> m $ ContractHandler (MarketplaceTezOffchainEntrypoints Never) (MarketplaceTezOffchainStorage ())
 originateOffchainTezMarketplaceContract Setup{storage, seller, assetFA2} = do
-  contract <- TAddress @(MarketplaceTezOffchainEntrypoints ()) <$> originateUntypedSimple "marketplace-tez-offchain"
-    (untypeValue $ toVal storage)
-    (convertContract marketplaceTezOffchainContract)
+  contract <- originateSimple "marketplace-tez-offchain"
+    storage
+    marketplaceTezOffchainContract
 
   -- Make the contract an operator for the seller.
   withSender seller $ do
@@ -382,30 +364,30 @@ originateOffchainTezMarketplaceContract Setup{storage, seller, assetFA2} = do
 -- Call entrypoints
 ----------------------------------------------------------------------------
 
-confirmPurchase :: (HasCallStack, MonadNettest caps base m) => Address -> TAddress (MarketplaceTezOffchainEntrypoints ()) -> m ()
-confirmPurchase buyer contract = 
-    call contract (Call @"Confirm_purchases") 
+confirmPurchase :: (HasCallStack, MonadNettest caps base m) => Address -> ContractHandler (MarketplaceTezOffchainEntrypoints Never) st -> m ()
+confirmPurchase buyer contract =
+    call contract (Call @"Confirm_purchases")
       [
-        PendingPurchase 
+        PendingPurchase
           {
             saleId = SaleId 0
           , purchaser = buyer
           }
       ]
 
-revokePurchase :: (HasCallStack, MonadNettest caps base m) => Address -> TAddress (MarketplaceTezOffchainEntrypoints ()) -> m ()
-revokePurchase buyer contract = 
-    call contract (Call @"Revoke_purchases") 
+revokePurchase :: (HasCallStack, MonadNettest caps base m) => Address -> ContractHandler (MarketplaceTezOffchainEntrypoints Never) st -> m ()
+revokePurchase buyer contract =
+    call contract (Call @"Revoke_purchases")
       [
-        PendingPurchase 
+        PendingPurchase
           {
             saleId = SaleId 0
           , purchaser = buyer
           }
       ]
-    
 
-sell :: (HasCallStack, MonadNettest caps base m) => TestData -> Setup -> TAddress (MarketplaceTezOffchainEntrypoints ()) -> m ()
+
+sell :: (HasCallStack, MonadNettest caps base m) => TestData -> Setup -> ContractHandler (MarketplaceTezOffchainEntrypoints Never) st -> m ()
 sell TestData{testSalePrice, testTokenAmount} Setup{assetFA2} contract =
   call contract (Call @"Sell") SaleDataTez
     { saleToken = SaleToken
@@ -416,55 +398,55 @@ sell TestData{testSalePrice, testTokenAmount} Setup{assetFA2} contract =
     , tokenAmount = testTokenAmount
     }
 
--- a single buyer buys all by alternatively offchain buying and confirming 
-offchainBuyAll :: (HasCallStack, MonadNettest caps base m) => TestData -> Setup -> TAddress (MarketplaceTezOffchainEntrypoints ()) -> m ()
+-- a single buyer buys all by alternatively offchain buying and confirming
+offchainBuyAll :: (HasCallStack, MonadNettest caps base m) => TestData -> Setup -> ContractHandler (MarketplaceTezOffchainEntrypoints Never) st -> m ()
 offchainBuyAll TestData{testTokenAmount} Setup{buyer} contract = do
     forM_ [1 .. testTokenAmount] \permitCounter -> do
       offchainBuy buyer permitCounter contract
       confirmPurchase buyer contract
 
 -- N addresses buy all N assets in a sale conseutively, and then all N are confirmed
-offchainBuyAllConsecutive :: (HasCallStack, MonadNettest caps base m) => TestData -> TAddress (MarketplaceTezOffchainEntrypoints ()) -> m ()
+offchainBuyAllConsecutive :: (HasCallStack, MonadNettest caps base m) => TestData -> ContractHandler (MarketplaceTezOffchainEntrypoints Never) st -> m ()
 offchainBuyAllConsecutive TestData{testTokenAmount} contract = do
-  addresses <- mkNAddresses testTokenAmount 
+  addresses <- mkNAddresses testTokenAmount
   forM_  (zip [1 .. testTokenAmount] addresses) ( \(counter, buyer) -> do
       offchainBuy buyer counter contract
-      pure (counter + 1) 
+      pure (counter + 1)
     )
   mapM_ (`confirmPurchase` contract) addresses
 
--- N addresses buy all N assets in a sale by submitting N permits that are submitted to the contract together in batch. 
-offchainBuyAllBatch :: (HasCallStack, MonadNettest caps base m) => TestData -> TAddress (MarketplaceTezOffchainEntrypoints ()) -> m ()
+-- N addresses buy all N assets in a sale by submitting N permits that are submitted to the contract together in batch.
+offchainBuyAllBatch :: (HasCallStack, MonadNettest caps base m) => TestData -> ContractHandler (MarketplaceTezOffchainEntrypoints Never) st -> m ()
 offchainBuyAllBatch TestData{testTokenAmount} contract = do
-    addresses <- mkNAddresses testTokenAmount 
+    addresses <- mkNAddresses testTokenAmount
     offchainBuyBatch addresses contract
     mapM_ (`confirmPurchase` contract) addresses
 
 mkNAddresses :: (HasCallStack, MonadNettest caps base m) => Natural -> m [Address]
-mkNAddresses n =  
-    forM [1 .. n] (newAddress . AliasHint . show)
+mkNAddresses n =
+    replicateM (fromIntegral n) (newAddress auto)
 
-mkPermitToForge :: (HasCallStack, MonadNettest caps base m) => SaleId -> Natural -> TAddress (MarketplaceTezOffchainEntrypoints ()) -> m (ByteString, PublicKey)
-mkPermitToForge buyParam counter contract = do 
+mkPermitToForge :: (HasCallStack, MonadNettest caps base m) => SaleId -> Natural -> ContractHandler (MarketplaceTezOffchainEntrypoints Never) st -> m (ByteString, PublicKey)
+mkPermitToForge buyParam counter contract = do
   aliasAddress <- newAddress "forged"
   aliasPK <- getPublicKey aliasAddress
-  unsignedPermit <- mkPermitToSign buyParam counter contract 
+  unsignedPermit <- mkPermitToSign buyParam counter contract
   pure (unsignedPermit, aliasPK)
 
-mkPermitToSign :: (HasCallStack, MonadNettest caps base m) => SaleId -> Natural -> TAddress (MarketplaceTezOffchainEntrypoints ()) -> m ByteString
-mkPermitToSign buyParam counter contract = do 
+mkPermitToSign :: (HasCallStack, MonadNettest caps base m) => SaleId -> Natural -> ContractHandler (MarketplaceTezOffchainEntrypoints Never) st -> m ByteString
+mkPermitToSign buyParam counter contract = do
   marketplaceChainId <- getChainId
   let unsigned = packValue' $ toVal ((marketplaceChainId, marketplaceAddress), (counter, buyParamHash))
   pure unsigned
-  where buyParamHash = blake2b $ packValue' $ toVal buyParam 
+  where buyParamHash = blake2b $ packValue' $ toVal buyParam
         marketplaceAddress = toAddress contract
 
-offchainBuy :: (HasCallStack, MonadNettest caps base m) => Address -> Natural -> TAddress (MarketplaceTezOffchainEntrypoints ()) -> m ()
+offchainBuy :: (HasCallStack, MonadNettest caps base m) => Address -> Natural -> ContractHandler (MarketplaceTezOffchainEntrypoints Never) st -> m ()
 offchainBuy buyer counter contract = do
   buyerPK <- getPublicKey buyer
   unsigned <- mkPermitToSign buyParam counter contract
-  signature <- signBytes unsigned buyer 
-  call contract (Call @"Offchain_buy") 
+  signature <- signBytes unsigned buyer
+  call contract (Call @"Offchain_buy")
     [OffchainBuyParam
       {
         saleId = buyParam
@@ -472,35 +454,35 @@ offchainBuy buyer counter contract = do
           {
             signerKey = buyerPK
           , signature = signature
-          } 
+          }
       }
     ]
-  where buyParam = SaleId 0 
+  where buyParam = SaleId 0
 
-offchainBuyBatch :: (HasCallStack, MonadNettest caps base m) => [Address] -> TAddress (MarketplaceTezOffchainEntrypoints ()) -> m ()
+offchainBuyBatch :: (HasCallStack, MonadNettest caps base m) => [Address] -> ContractHandler (MarketplaceTezOffchainEntrypoints Never) st -> m ()
 offchainBuyBatch buyers contract = do
-  let numBuyers = length buyers 
+  let numBuyers = length buyers
   param <- forM (zip [1 .. numBuyers] buyers) $ \(counter, buyer) -> do
     buyerPK <- getPublicKey buyer
     unsigned <- mkPermitToSign buyParam (fromIntegral counter) contract
     signature <- signBytes unsigned buyer
-    return OffchainBuyParam { 
+    return OffchainBuyParam {
         saleId = buyParam
       , permit = Permit
           {
             signerKey = buyerPK
           , signature = signature
-          } 
-      } 
-  call contract (Call @"Offchain_buy") param 
-  where buyParam = SaleId 0 
+          }
+      }
+  call contract (Call @"Offchain_buy") param
+  where buyParam = SaleId 0
 
-offchainBuyForged :: (HasCallStack, MonadNettest caps base m) => Address -> Natural -> TAddress (MarketplaceTezOffchainEntrypoints ()) -> m ByteString
+offchainBuyForged :: (HasCallStack, MonadNettest caps base m) => Address -> Natural -> ContractHandler (MarketplaceTezOffchainEntrypoints Never) st -> m ByteString
 offchainBuyForged buyer counter contract = do
-  let buyParam = SaleId 0 
+  let buyParam = SaleId 0
   (unsigned, forgedPK) <- mkPermitToForge buyParam counter contract
-  signature <- signBytes unsigned buyer 
-  (\() -> unsigned) <$> call contract (Call @"Offchain_buy") 
+  signature <- signBytes unsigned buyer
+  (\() -> unsigned) <$> call contract (Call @"Offchain_buy")
     [OffchainBuyParam
       {
         saleId = buyParam
@@ -508,11 +490,11 @@ offchainBuyForged buyer counter contract = do
           {
             signerKey = forgedPK
           , signature = signature
-          } 
+          }
       }
-    ] 
-  
-buy :: (HasCallStack, MonadNettest caps base m) => TestData -> TAddress (MarketplaceTezOffchainEntrypoints ()) -> m ()
+    ]
+
+buy :: (HasCallStack, MonadNettest caps base m) => TestData -> ContractHandler (MarketplaceTezOffchainEntrypoints Never) st -> m ()
 buy TestData{testSalePrice} contract =
   transfer TransferData
     { tdTo = contract
@@ -521,7 +503,7 @@ buy TestData{testSalePrice} contract =
     , tdParameter = SaleId 0
     }
 
-buyAll :: (HasCallStack, MonadNettest caps base m) => TestData -> TAddress (MarketplaceTezOffchainEntrypoints ()) -> m ()
+buyAll :: (HasCallStack, MonadNettest caps base m) => TestData -> ContractHandler (MarketplaceTezOffchainEntrypoints Never) st -> m ()
 buyAll testData@TestData{testTokenAmount} contract =
   replicateM_ (fromIntegral testTokenAmount) $
     buy testData contract

--- a/packages/minter-contracts/test-hs/Test/Marketplace/Util.hs
+++ b/packages/minter-contracts/test-hs/Test/Marketplace/Util.hs
@@ -9,67 +9,68 @@ module Test.Marketplace.Util
   ) where
 
 import Lorentz.Value
-import qualified Michelson.Typed as T
 import Morley.Nettest
 
 import Lorentz.Contracts.AllowlistSimple as AllowlistSimple
 import Lorentz.Contracts.AllowlistToken as AllowlistToken
+import Lorentz.Contracts.Marketplace.Contracts
 import Lorentz.Contracts.Marketplace.FA2
 import Lorentz.Contracts.Marketplace.Tez
 import Lorentz.Contracts.Marketplace.TezOffchain
+import Lorentz.Contracts.NoAllowlist as NoAllowlist
 import qualified Lorentz.Contracts.PausableAdminOption as PausableAdminOption
 
 originateMarketplaceAllowlisted
   :: MonadNettest caps base m
   => Address
-  -> m (TAddress $ MarketplaceEntrypoints AllowlistSimple.Entrypoints)
+  -> m $ ContractHandler
+       (MarketplaceEntrypoints AllowlistSimple.Entrypoints)
+       (MarketplaceStorage AllowlistSimple.Allowlist)
 originateMarketplaceAllowlisted admin = do
-  TAddress <$> originateUntypedSimple "marketplace"
-    (T.untypeValue $ T.toVal $
-      initMarketplaceStorage @AllowlistSimple.Allowlist
-        (PausableAdminOption.initAdminStorage admin))
-    (T.convertContract marketplaceAllowlistedContract)
+  originateSimple "marketplace"
+    (initMarketplaceStorage (PausableAdminOption.initAdminStorage admin))
+    marketplaceAllowlistedContract
 
 originateMarketplaceAllowlistedToken
   :: MonadNettest caps base m
   => Address
-  -> m (TAddress $ MarketplaceEntrypoints AllowlistToken.Entrypoints)
+  -> m $ ContractHandler
+       (MarketplaceEntrypoints AllowlistToken.Entrypoints)
+       (MarketplaceStorage AllowlistToken.Allowlist)
 originateMarketplaceAllowlistedToken admin = do
-  TAddress <$> originateUntypedSimple "marketplace"
-    (T.untypeValue $ T.toVal $
-      initMarketplaceStorage @AllowlistToken.Allowlist
-        (PausableAdminOption.initAdminStorage admin))
-    (T.convertContract marketplaceAllowlistedTokenContract)
+  originateSimple "marketplace"
+    (initMarketplaceStorage (PausableAdminOption.initAdminStorage admin))
+    marketplaceAllowlistedTokenContract
 
 originateMarketplaceTezAllowlisted
   :: MonadNettest caps base m
   => Address
-  -> m (TAddress $ MarketplaceTezEntrypoints AllowlistSimple.Entrypoints)
+  -> m $ ContractHandler
+       (MarketplaceTezEntrypoints AllowlistSimple.Entrypoints)
+       (MarketplaceTezStorage AllowlistSimple.Allowlist)
 originateMarketplaceTezAllowlisted admin = do
-  TAddress <$> originateUntypedSimple "marketplace-tez"
-    (T.untypeValue $ T.toVal $
-      initMarketplaceTezStorage @AllowlistSimple.Allowlist
-        (PausableAdminOption.initAdminStorage admin))
-    (T.convertContract marketplaceTezAllowlistedContract)
+  originateSimple "marketplace-tez"
+    (initMarketplaceTezStorage (PausableAdminOption.initAdminStorage admin))
+    marketplaceTezAllowlistedContract
 
 originateMarketplaceTezAllowlistedToken
   :: MonadNettest caps base m
   => Address
-  -> m (TAddress $ MarketplaceTezEntrypoints AllowlistToken.Entrypoints)
+  -> m $ ContractHandler
+       (MarketplaceTezEntrypoints AllowlistToken.Entrypoints)
+       (MarketplaceTezStorage AllowlistToken.Allowlist)
 originateMarketplaceTezAllowlistedToken admin = do
-  TAddress <$> originateUntypedSimple "marketplace-tez"
-    (T.untypeValue $ T.toVal $
-      initMarketplaceTezStorage @AllowlistToken.Allowlist
-        (PausableAdminOption.initAdminStorage admin))
-    (T.convertContract marketplaceTezAllowlistedTokenContract)
+  originateSimple "marketplace-tez"
+    (initMarketplaceTezStorage (PausableAdminOption.initAdminStorage admin))
+    marketplaceTezAllowlistedTokenContract
 
 originateOffchainTezMarketplace
   :: MonadNettest caps base m
   => Address
-  -> m (TAddress $ MarketplaceTezOffchainEntrypoints AllowlistSimple.Entrypoints)
+  -> m $ ContractHandler
+       (MarketplaceTezOffchainEntrypoints NoAllowlist.Entrypoints)
+       (MarketplaceTezOffchainStorage NoAllowlist.Allowlist)
 originateOffchainTezMarketplace admin = do
-  TAddress <$> originateUntypedSimple "marketplace"
-    (T.untypeValue $ T.toVal $
-      initMarketplaceTezOffchainStorage @AllowlistSimple.Allowlist
-        (PausableAdminOption.initAdminStorage admin))
-    (T.convertContract marketplaceTezOffchainContract)
+  originateSimple "marketplace"
+    (initMarketplaceTezOffchainStorage (PausableAdminOption.initAdminStorage admin))
+    marketplaceTezOffchainContract

--- a/packages/minter-contracts/test-hs/Test/NonPausableSimpleAdmin.hs
+++ b/packages/minter-contracts/test-hs/Test/NonPausableSimpleAdmin.hs
@@ -15,9 +15,9 @@ import Morley.Nettest.Tasty (nettestScenarioCaps)
 
 import Lorentz.Contracts.NonPausableSimpleAdmin
 
-type OriginateAdminContractFn param =
+type OriginateAdminContractFn param storage =
   forall m. (Monad m)
-  => Address -> NettestT m (TAddress param)
+  => Address -> NettestT m (ContractHandler param storage)
 
 adminOwnershipTransferChecks
   :: ( ParameterContainsEntrypoints param
@@ -25,7 +25,7 @@ adminOwnershipTransferChecks
         , "Confirm_admin" :> ()
         ]
      )
-  => OriginateAdminContractFn param
+  => OriginateAdminContractFn param storage
   -> TestTree
 adminOwnershipTransferChecks originateFn = testGroup "Admin functionality"
   [ nettestScenarioCaps "Ownership transfer works" $ do
@@ -46,14 +46,14 @@ adminOwnershipTransferChecks originateFn = testGroup "Admin functionality"
       successor <- newAddress "successor"
       contract <- originateFn admin
       call contract (Call @"Set_admin") successor
-        & expectError contract errNotAdmin
+        & expectError errNotAdmin
 
   , nettestScenarioCaps "Cannot accept ownership before prior transfer of it" $ do
       admin <- newAddress "admin"
       contract <- originateFn admin
 
       call contract (Call @"Confirm_admin") ()
-        & expectError contract noPendingAdmin
+        & expectError noPendingAdmin
 
   , nettestScenarioCaps "Not pending admin cannot confirm ownership" $ do
       admin <- newAddress "admin"
@@ -63,6 +63,6 @@ adminOwnershipTransferChecks originateFn = testGroup "Admin functionality"
       call contract (Call @"Set_admin") successor
         & withSender admin
       call contract (Call @"Confirm_admin") ()
-        & expectError contract notPendingAdmin
+        & expectError notPendingAdmin
 
   ]

--- a/packages/minter-contracts/test-hs/Test/PausableWallet.hs
+++ b/packages/minter-contracts/test-hs/Test/PausableWallet.hs
@@ -1,13 +1,13 @@
-module Test.PausableWallet where 
+module Test.PausableWallet where
 
 import Lorentz.Contracts.PausableWallet
+import Lorentz.Contracts.PausableWalletContract
 import Lorentz.Contracts.SimpleAdmin
 import Lorentz.Value
-import qualified Michelson.Typed as T
 import Morley.Nettest
+import Morley.Nettest.Tasty (nettestScenarioCaps)
 import Test.SimpleAdmin
 import Test.Tasty (TestTree, testGroup)
-import Morley.Nettest.Tasty (nettestScenarioCaps)
 
 test_AdminChecks :: TestTree
 test_AdminChecks =
@@ -17,46 +17,46 @@ test_PausableDefault :: TestTree
 test_PausableDefault = testGroup "Send tez to default"
   [ nettestScenarioCaps "Tez can be sent to default when unpaused" $ do
     admin <- newAddress "admin"
-    wallet <- originatePausableWallet admin 
+    wallet <- originatePausableWallet admin
     call wallet CallDefault ()
   , nettestScenarioCaps "Tez cannot be sent to default when Paused" $ do
     admin <- newAddress "admin"
-    wallet <- originatePausableWallet admin 
-    withSender admin $ 
+    wallet <- originatePausableWallet admin
+    withSender admin $
       call wallet (Call @"Pause") True
     transfer TransferData
      { tdTo = wallet
      , tdAmount = toMutez 10
      , tdEntrypoint = DefEpName
      , tdParameter = ()
-     } 
-      & expectError wallet errPaused
+     }
+      & expectError errPaused
   ]
 
 test_SendAdminChecked :: TestTree
 test_SendAdminChecked = testGroup "Send must be admin checked"
   [ nettestScenarioCaps "Send entrypoint is admin checked" $ do
     admin <- newAddress "admin"
-    wallet <- originatePausableWallet admin 
+    wallet <- originatePausableWallet admin
     call wallet CallDefault ()
     call wallet (Call @"Send") 10
-      & expectError wallet errNotAdmin 
+      & expectError errNotAdmin
   ]
 
 test_DefaultReceivesFee :: TestTree
 test_DefaultReceivesFee  = testGroup "Default entrypoint receives fee sent"
   [ nettestScenarioCaps "Default entrypoint receives fee sent" $ do
     admin <- newAddress "admin"
-    wallet <- originatePausableWallet admin 
-    initWalletBalance <- getBalance wallet 
+    wallet <- originatePausableWallet admin
+    initWalletBalance <- getBalance wallet
     transfer TransferData
      { tdTo = wallet
      , tdAmount = toMutez 10
      , tdEntrypoint = DefEpName
      , tdParameter = ()
-     } 
+     }
     finalWalletBalance <- getBalance wallet
-    let amountReceived = finalWalletBalance - initWalletBalance 
+    let amountReceived = finalWalletBalance - initWalletBalance
     amountReceived @== 10
   ]
 
@@ -64,27 +64,26 @@ test_SendsAmount :: TestTree
 test_SendsAmount = testGroup "Send sends correct amount"
   [ nettestScenarioCaps "Send sends correct amount" $ do
     admin <- newAddress "admin"
-    wallet <- originatePausableWallet admin 
+    wallet <- originatePausableWallet admin
     transfer TransferData
      { tdTo = wallet
      , tdAmount = toMutez 10
      , tdEntrypoint = DefEpName
      , tdParameter = ()
-     } 
-    initWalletBalance <- getBalance wallet  
+     }
+    initWalletBalance <- getBalance wallet
     withSender admin $
       call wallet (Call @"Send") 10
     finalWalletBalance <- getBalance wallet
-    let amountSent = initWalletBalance - finalWalletBalance 
+    let amountSent = initWalletBalance - finalWalletBalance
     amountSent @== 10
   ]
 
 originatePausableWallet
   :: MonadNettest caps base m
   => Address
-  -> m (TAddress PausableWalletEntrypoints)
+  -> m (ContractHandler PausableWalletEntrypoints PausableWalletStorage)
 originatePausableWallet admin = do
-  TAddress <$> originateUntypedSimple "pausable-wallet"
-    (T.untypeValue $ T.toVal $
-      initPausableWalletStorage admin)
-    (T.convertContract pausableWalletContract)
+  originateSimple "pausable-wallet"
+    (initPausableWalletStorage admin)
+    pausableWalletContract

--- a/packages/minter-contracts/test-hs/Test/SimpleAdmin.hs
+++ b/packages/minter-contracts/test-hs/Test/SimpleAdmin.hs
@@ -15,9 +15,9 @@ import Morley.Nettest.Tasty (nettestScenarioCaps)
 
 import Lorentz.Contracts.SimpleAdmin
 
-type OriginateAdminContractFn param =
+type OriginateAdminContractFn param storage =
   forall m. (Monad m)
-  => Address -> NettestT m (TAddress param)
+  => Address -> NettestT m (ContractHandler param storage)
 
 adminOwnershipTransferChecks
   :: ( ParameterContainsEntrypoints param
@@ -26,7 +26,7 @@ adminOwnershipTransferChecks
         , "Pause" :> Bool
         ]
      )
-  => OriginateAdminContractFn param
+  => OriginateAdminContractFn param storage
   -> TestTree
 adminOwnershipTransferChecks originateFn = testGroup "Admin functionality"
   [ nettestScenarioCaps "Ownership transfer works" $ do
@@ -47,26 +47,26 @@ adminOwnershipTransferChecks originateFn = testGroup "Admin functionality"
       successor <- newAddress "successor"
       contract <- originateFn admin
       call contract (Call @"Set_admin") successor
-        & expectError contract errNotAdmin
-  
+        & expectError errNotAdmin
+
   , nettestScenarioCaps "Non-admin cannot pause" $ do
     admin <- newAddress "admin"
     contract <- originateFn admin
     call contract (Call @"Pause") True
-      & expectError contract errNotAdmin
+      & expectError errNotAdmin
 
   , nettestScenarioCaps "Non-admin cannot unpause" $ do
     admin <- newAddress "admin"
     contract <- originateFn admin
     call contract (Call @"Pause") False
-      & expectError contract errNotAdmin
+      & expectError errNotAdmin
 
   , nettestScenarioCaps "Cannot accept ownership before prior transfer of it" $ do
       admin <- newAddress "admin"
       contract <- originateFn admin
 
       call contract (Call @"Confirm_admin") ()
-        & expectError contract noPendingAdmin
+        & expectError noPendingAdmin
 
   , nettestScenarioCaps "Not pending admin cannot confirm ownership" $ do
       admin <- newAddress "admin"
@@ -76,6 +76,6 @@ adminOwnershipTransferChecks originateFn = testGroup "Admin functionality"
       call contract (Call @"Set_admin") successor
         & withSender admin
       call contract (Call @"Confirm_admin") ()
-        & expectError contract notPendingAdmin
+        & expectError notPendingAdmin
 
   ]

--- a/packages/minter-contracts/test-hs/Test/Swaps/AllowlistedFee.hs
+++ b/packages/minter-contracts/test-hs/Test/Swaps/AllowlistedFee.hs
@@ -9,8 +9,8 @@ import Lorentz.Value
 import Morley.Nettest
 import Morley.Nettest.Tasty (nettestScenarioCaps)
 
-import Lorentz.Contracts.Swaps.Basic hiding (SwapOffer, mkSingleOffer, mkNOffers)
 import Lorentz.Contracts.Swaps.AllowlistedFee
+import Lorentz.Contracts.Swaps.Basic hiding (SwapOffer, mkNOffers, mkSingleOffer)
 import Test.Swaps.Util
 import Test.Util
 
@@ -54,7 +54,7 @@ test_ContractSendsFee = testGroup "Tests that contract sends fee"
 
       withSender admin $
         call swap (Call @"Update_allowed") (mkAllowlistSimpleParam [fa2])
-    
+
       withSender admin $
           call swap (Call @"Start") $ mkSingleOffer SwapOffer
             { assetsOffered = [mkFA2Assets fa2 [(tokenId, 10)]]
@@ -67,12 +67,12 @@ test_ContractSendsFee = testGroup "Tests that contract sends fee"
             , tdEntrypoint = ep "accept"
             , tdParameter = initSwapId
             }
-      
+
       sellerBalanceAfter <- getBalance admin
       buyerBalanceAfter <- getBalance alice
-    
+
       sellerBalanceAfter @== sellerBalanceBefore + amountRequested
-      buyerBalanceAfter @== buyerBalanceBefore - amountRequested 
+      buyerBalanceAfter @== buyerBalanceBefore - amountRequested
   ]
 
 test_BuyerMustSendFee :: TestTree
@@ -87,7 +87,7 @@ test_BuyerMustSendFee = testGroup "Tests that buyer must send fee"
 
       withSender admin $
         call swap (Call @"Update_allowed") (mkAllowlistSimpleParam [fa2])
-    
+
       withSender admin $
           call swap (Call @"Start") $ mkSingleOffer SwapOffer
             { assetsOffered = [mkFA2Assets fa2 [(tokenId, 10)]]
@@ -99,6 +99,6 @@ test_BuyerMustSendFee = testGroup "Tests that buyer must send fee"
             , tdAmount = toMutez 0
             , tdEntrypoint = ep "accept"
             , tdParameter = initSwapId
-            } 
-          & expectError swap errNoXtzTransferred
+            }
+          & expectError errNoXtzTransferred
   ]

--- a/packages/minter-contracts/test-hs/Test/Swaps/Collections.hs
+++ b/packages/minter-contracts/test-hs/Test/Swaps/Collections.hs
@@ -13,7 +13,7 @@ import qualified Hedgehog.Range as Range
 import qualified Lorentz.Contracts.Spec.FA2Interface as FA2I
 
 import qualified Indigo.Contracts.FA2Sample as FA2
-import Michelson.Interpret.Pack 
+import Michelson.Interpret.Pack
 
 import GHC.Integer (negateInteger)
 
@@ -26,14 +26,14 @@ import Lorentz.Address
 
 import qualified Lorentz.Contracts.Swaps.Basic as Basic
 import Lorentz.Contracts.Swaps.Collections
-import Lorentz.Value
 import Lorentz.Test (contractConsumer)
+import Lorentz.Value
 
 import Lorentz.Contracts.Spec.FA2Interface (TokenId(..))
 
+import Test.NonPausableSimpleAdmin
 import Test.Swaps.Util
 import Test.Util
-import Test.NonPausableSimpleAdmin
 
 import Tezos.Address (unsafeParseAddress)
 import Tezos.Crypto
@@ -50,7 +50,7 @@ genTestData = do
   let genNat = Gen.integral (Range.constant 1 20)
   numOffers <- genNat
   token1Offer <- genNat
-  token2Offer <- genNat 
+  token2Offer <- genNat
   pure $ TestData
     { numOffers = numOffers
     , token1Offer = token1Offer
@@ -74,7 +74,7 @@ hprop_Sending_fake_permit_to_offchain_accept_fails =
       swap <- originateOffchainCollections admin fa2Address
       withSender admin $
         addCollection (Set.fromList tokensList) swap
-      withSender alice $ 
+      withSender alice $
         addOperatorOnTokens tokensList (toAddress swap) alice fa2
       withSender admin $ do
         addOperatorOnTokens [adminToken] (toAddress swap) admin fa2
@@ -83,13 +83,14 @@ hprop_Sending_fake_permit_to_offchain_accept_fails =
           , assetsRequested = [initCollectionId]
           }
       let acceptParam = AcceptParam {
-            swapId = Basic.initSwapId , 
+            swapId = Basic.initSwapId ,
             tokensSent = one $ (initCollectionId, tokenId1)
           }
       missignedBytes <- fst <$> mkPermitToForge acceptParam swap
       withSender admin $ do
-        (offchainAcceptForged acceptParam alice swap) `expectFailure` failedWith swap
-          ([mt|MISSIGNED|], missignedBytes)
+        (offchainAcceptForged acceptParam alice swap)
+          & expectTransferFailure
+            [failedWith $ constant ([mt|MISSIGNED|], missignedBytes)]
 
 hprop_Offchain_accept_not_admin_submitted_fails :: Property
 hprop_Offchain_accept_not_admin_submitted_fails =
@@ -104,7 +105,7 @@ hprop_Offchain_accept_not_admin_submitted_fails =
       swap <- originateOffchainCollections admin fa2Address
       withSender admin $
         addCollection (Set.fromList tokensList) swap
-      withSender alice $ 
+      withSender alice $
         addOperatorOnTokens tokensList (toAddress swap) alice fa2
       withSender admin $ do
         addOperatorOnTokens [adminToken] (toAddress swap) admin fa2
@@ -114,7 +115,8 @@ hprop_Offchain_accept_not_admin_submitted_fails =
           }
       let tokensSent = one $ (initCollectionId, tokenId1)
       withSender alice $ do
-        (offchainAccept tokensSent alice swap) `expectFailure` failedWith swap errNotAdmin
+        offchainAccept tokensSent alice swap
+          & expectTransferFailure [failedWith $ constant errNotAdmin]
 
 hprop_Consecutive_offchain_accept_equals_iterative_accept :: Property
 hprop_Consecutive_offchain_accept_equals_iterative_accept =
@@ -123,7 +125,7 @@ hprop_Consecutive_offchain_accept_equals_iterative_accept =
       clevelandProp $ do
         setup <- doFA2Setup @("addresses" :# 50) @("tokens" :# 2)
         let admin1 ::< admin2 ::< remainingAddresses = sAddresses setup
-        let addresses = take (fromIntegral numOffers) (Sized.toList remainingAddresses) 
+        let addresses = take (fromIntegral numOffers) (Sized.toList remainingAddresses)
         let tokenId1 ::< tokenId2 ::< SNil = sTokens setup
         fa2_1 <- originateFA2 "fa2_1" setup []
         fa2_2 <- originateFA2 "fa2_2" setup []
@@ -133,34 +135,28 @@ hprop_Consecutive_offchain_accept_equals_iterative_accept =
           addOperatorOnTokens [tokenId1, tokenId2] (toAddress swap1) admin1 fa2_1
         withSender admin2 $ do
           addOperatorOnTokens [tokenId1, tokenId2] (toAddress swap2) admin2 fa2_2
-        withSender admin1 $ do 
+        withSender admin1 $ do
           call swap1 (Call @"Start") $ mkNOffers numOffers SwapOffer
                { assetsOffered = Basic.tokens  $ mkFA2Assets fa2_1 [(tokenId1, token1Offer), (tokenId2, token2Offer)]
                , assetsRequested = []
                }
-        withSender admin2 $ do 
+        withSender admin2 $ do
           call swap2 (Call @"Start") $ mkNOffers numOffers SwapOffer
                { assetsOffered = Basic.tokens  $ mkFA2Assets fa2_2 [(tokenId1, token1Offer), (tokenId2, token2Offer)]
                , assetsRequested = []
                }
 
         let acceptParam = AcceptParam {
-            swapId = Basic.initSwapId , 
+            swapId = Basic.initSwapId ,
             tokensSent = Set.empty
           }
         withSender admin1 $ do
           offchainAcceptAllConsecutive Set.empty addresses swap1
         withSender admin2 $ do
           offchainAcceptBatch acceptParam addresses swap2
-      
-        swapStorage1 <-  toVal <$>
-                         swaps <$>
-                         fromVal @CollectionsStorage <$> 
-                         getStorage' swap1
-        swapStorage2 <-  toVal <$>
-                         swaps <$>
-                         fromVal @CollectionsStorage <$> 
-                         getStorage' swap2
+
+        swapStorage1 <- toVal . swaps <$> getStorage' swap1
+        swapStorage2 <- toVal . swaps <$> getStorage' swap2
         swapStorage1 @== swapStorage2
 
 ------------------------------------------------------------------------------
@@ -181,7 +177,7 @@ hprop_Accepting_with_zero_balance_fails =
           addressWithZeroBalance <- newAddress "test"
           withSender admin $
             addCollection (Set.fromList tokensList) swap
-          withSender addressWithZeroBalance $ 
+          withSender addressWithZeroBalance $
             addOperatorOnTokens tokensList (toAddress swap) addressWithZeroBalance fa2
           withSender admin $ do
             addOperatorOnTokens [adminToken] (toAddress swap) admin fa2
@@ -192,13 +188,13 @@ hprop_Accepting_with_zero_balance_fails =
               }
           let tokensSent = Set.fromList [(initCollectionId, tokenId1), (initCollectionId, tokenId2)]
           withSender admin
-            ((offchainAccept tokensSent addressWithZeroBalance swap)
-              `expectFailure` failedWith fa2 (errSwapRequestedFA2BalanceInvalid 1 0))  
+            (offchainAccept tokensSent addressWithZeroBalance swap
+              & expectTransferFailure [failedWith $ constant (errSwapRequestedFA2BalanceInvalid 1 0)])
 
 hprop_Start_callable_by_admin_only :: Property
-hprop_Start_callable_by_admin_only = 
+hprop_Start_callable_by_admin_only =
   property $ do
-   TestData{numOffers} <- forAll genTestData 
+   TestData{numOffers} <- forAll genTestData
    clevelandProp $ do
      setup <- doFA2Setup
      let admin ::< nonAdmin ::< SNil = sAddresses setup
@@ -206,16 +202,16 @@ hprop_Start_callable_by_admin_only =
      fa2 <- originateFA2 "fa2" setup []
      let fa2Address = toAddress fa2
      swap <- originateOffchainCollections admin fa2Address
-     withSender nonAdmin 
+     withSender nonAdmin
        (call swap (Call @"Start") (mkNOffers numOffers SwapOffer
          { assetsOffered = []
          , assetsRequested = []
-         }) & expectError swap errNotAdmin)
+         }) & expectError errNotAdmin)
 
 hprop_Correct_final_balances_on_acceptance :: Property
-hprop_Correct_final_balances_on_acceptance = 
+hprop_Correct_final_balances_on_acceptance =
   property $ do
-   TestData{numOffers, token1Offer, token2Offer} <- forAll genTestData 
+   TestData{numOffers, token1Offer, token2Offer} <- forAll genTestData
    clevelandProp  $ do
       setup <- doFA2Setup
       let admin ::< alice ::< SNil = sAddresses setup
@@ -223,14 +219,14 @@ hprop_Correct_final_balances_on_acceptance =
       fa2 <- originateFA2 "fa2" setup []
       let fa2Address = toAddress fa2
       swap <- originateOffchainCollections admin fa2Address
-      withSender alice $ 
+      withSender alice $
        addOperatorOnTokens' [tokenId1, tokenId2] (toAddress swap) alice fa2
       withSender admin $ do
        addOperatorOnTokens' [tokenId1, tokenId2] (toAddress swap) admin fa2
        addCollection' (Set.fromList [tokenId1, tokenId2]) swap
        addCollection' (Set.fromList [tokenId3, tokenId4]) swap
-    
-      assertingBurnAddressUnchanged swap $ do 
+
+      assertingBurnAddressUnchanged swap $ do
         assertingBalanceDeltas fa2
           [ (admin, tokenId1) -: negateInteger (fromIntegral $ token1Offer * numOffers)
           , (admin, tokenId2) -: negateInteger (fromIntegral $ token2Offer * numOffers)
@@ -246,16 +242,16 @@ hprop_Correct_final_balances_on_acceptance =
                 { assetsOffered = Basic.tokens  $ mkFA2Assets fa2 [(tokenId1, token1Offer), (tokenId2, token2Offer)]
                 , assetsRequested = [initCollectionId, initCollectionId, incrementCollectionId initCollectionId, incrementCollectionId initCollectionId]
                 }
-            let tokensSent = Set.fromList [(initCollectionId, tokenId1), (initCollectionId, tokenId2), 
-                                           (incrementCollectionId initCollectionId, tokenId3), 
+            let tokensSent = Set.fromList [(initCollectionId, tokenId1), (initCollectionId, tokenId2),
+                                           (incrementCollectionId initCollectionId, tokenId3),
                                            (incrementCollectionId initCollectionId, tokenId4)]
             withSender admin $
               offchainAccept tokensSent alice swap
-  
+
 hprop_Correct_final_balances_on_cancel :: Property
-hprop_Correct_final_balances_on_cancel = 
+hprop_Correct_final_balances_on_cancel =
   property $ do
-   TestData{numOffers, token1Offer, token2Offer} <- forAll genTestData 
+   TestData{numOffers, token1Offer, token2Offer} <- forAll genTestData
    clevelandProp  $ do
       setup <- doFA2Setup
       let admin ::< alice ::< SNil = sAddresses setup
@@ -263,10 +259,10 @@ hprop_Correct_final_balances_on_cancel =
       fa2 <- originateFA2 "fa2" setup []
       let fa2Address = toAddress fa2
       swap <- originateOffchainCollections admin fa2Address
-      withSender admin $ 
+      withSender admin $
        addOperatorOnTokens' [tokenId1, tokenId2] (toAddress swap) admin fa2
 
-      assertingBurnAddressUnchanged swap $ do 
+      assertingBurnAddressUnchanged swap $ do
         assertingBalanceDeltas fa2
           [ (admin, tokenId1) -: 0
           , (admin, tokenId2) -: 0
@@ -282,11 +278,11 @@ hprop_Correct_final_balances_on_cancel =
                 }
             withSender admin $
               call swap (Call @"Cancel") Basic.initSwapId
---  
+--
 hprop_Correct_num_tokens_transferred_to_contract_on_start :: Property
-hprop_Correct_num_tokens_transferred_to_contract_on_start = 
+hprop_Correct_num_tokens_transferred_to_contract_on_start =
   property $ do
-   TestData{numOffers, token1Offer, token2Offer} <- forAll genTestData 
+   TestData{numOffers, token1Offer, token2Offer} <- forAll genTestData
    clevelandProp  $ do
      setup <- doFA2Setup
      let admin ::< SNil = sAddresses setup
@@ -294,10 +290,10 @@ hprop_Correct_num_tokens_transferred_to_contract_on_start =
      fa2 <- originateFA2 "fa2" setup []
      let fa2Address = toAddress fa2
      swap <- originateOffchainCollections admin fa2Address
-     withSender admin $ 
+     withSender admin $
        addOperatorOnTokens' [tokenId1, tokenId2] (toAddress swap) admin fa2
 
-     assertingBurnAddressUnchanged swap $ do 
+     assertingBurnAddressUnchanged swap $ do
        assertingBalanceDeltas fa2
          [ (admin, tokenId1) -: negateInteger (fromIntegral $ token1Offer * numOffers)
          , (admin, tokenId2) -: negateInteger (fromIntegral $ token2Offer * numOffers)
@@ -309,9 +305,9 @@ hprop_Correct_num_tokens_transferred_to_contract_on_start =
                }
 
 hprop_Contract_balance_goes_to_zero_when_sale_concludes :: Property
-hprop_Contract_balance_goes_to_zero_when_sale_concludes = 
+hprop_Contract_balance_goes_to_zero_when_sale_concludes =
   property $ do
-   TestData{numOffers, token1Offer, token2Offer} <- forAll genTestData 
+   TestData{numOffers, token1Offer, token2Offer} <- forAll genTestData
    clevelandProp  $ do
      setup <- doFA2Setup
      let admin ::< alice ::< SNil = sAddresses setup
@@ -320,12 +316,12 @@ hprop_Contract_balance_goes_to_zero_when_sale_concludes =
      let fa2Address = toAddress fa2
      swap <- originateOffchainCollections admin fa2Address
      let swapAddress = toAddress swap
-     withSender alice $ 
+     withSender alice $
        addOperatorOnTokens' [tokenId1, tokenId2] (toAddress swap) alice fa2
-     withSender admin $ 
+     withSender admin $
        addOperatorOnTokens' [tokenId1, tokenId2] (toAddress swap) admin fa2
 
-     assertingBurnAddressUnchanged swap $ do 
+     assertingBurnAddressUnchanged swap $ do
        assertingBalanceDeltas fa2
          [ (swapAddress, tokenId1) -: 0
          , (swapAddress, tokenId2) -: 0
@@ -338,8 +334,8 @@ hprop_Contract_balance_goes_to_zero_when_sale_concludes =
                }
            withSender admin $
               replicateM_ (fromIntegral numOffers) $ do
-                offchainAccept (Set.fromList [(initCollectionId, tokenId1), (initCollectionId, tokenId2)]) alice swap 
-  
+                offchainAccept (Set.fromList [(initCollectionId, tokenId1), (initCollectionId, tokenId2)]) alice swap
+
 test_CollectionsIntegrational :: TestTree
 test_CollectionsIntegrational = testGroup "Basic colections functionality"
   [ statusChecks
@@ -360,14 +356,14 @@ statusChecks = testGroup "Statuses"
       swap <- originateOffchainCollections admin fa2Address
       withSender admin $ do
         call swap (Call @"Start") $ mkSingleOffer $ SwapOffer [] []
-        let tokensSent = Set.empty 
+        let tokensSent = Set.empty
         offchainAccept' tokensSent alice swap
-      
+
         offchainAccept' tokensSent alice swap
-          & expectError swap errSwapFinished
-      
+          & expectError errSwapFinished
+
         offchainAccept' tokensSent alice swap
-          & expectError swap errSwapFinished
+          & expectError errSwapFinished
 
   , nettestScenarioCaps "Operations with cancelled swap fail" $ do
       setup <- doFA2Setup
@@ -376,32 +372,32 @@ statusChecks = testGroup "Statuses"
       fa2 <- originateFA2 "fa2" setup []
       let fa2Address = toAddress fa2
       swap <- originateOffchainCollections admin fa2Address
-      withSender admin $ do  
+      withSender admin $ do
         call swap (Call @"Start") $ mkSingleOffer $ SwapOffer [] []
         let tokensSent = Set.empty
         call swap (Call @"Cancel") Basic.initSwapId
 
         offchainAccept' tokensSent alice swap
-          & expectError swap errSwapCancelled
+          & expectError errSwapCancelled
 
         call swap (Call @"Cancel") Basic.initSwapId
-          & expectError swap errSwapCancelled
+          & expectError errSwapCancelled
   ]
 
 swapTokensSentChecks :: TestTree
 swapTokensSentChecks = testGroup "TokensSent"
-  [ nettestScenarioCaps "Sending too few tokens fails" $ do 
+  [ nettestScenarioCaps "Sending too few tokens fails" $ do
       setup <- doFA2Setup
       let admin ::< alice ::< SNil = sAddresses setup
       let tokenId1 ::< tokenId2 ::< tokenId3 ::< SNil = sTokens setup
       fa2 <- originateFA2 "fa2" setup []
       let fa2Address = toAddress fa2
       swap <- originateOffchainCollections admin fa2Address
-      
+
       withSender admin $ do
         addCollection' (Set.fromList [tokenId1, tokenId2, tokenId3]) swap
-      
-      withSender alice $ 
+
+      withSender alice $
        addOperatorOnTokens' [tokenId1, tokenId2, tokenId3] (toAddress swap) alice fa2
 
       withSender admin $
@@ -413,19 +409,19 @@ swapTokensSentChecks = testGroup "TokensSent"
       let tokensSent = Set.fromList [(initCollectionId , tokenId1), (initCollectionId , tokenId3)]
       withSender admin
         (offchainAccept' tokensSent alice swap)
-        & expectError swap errTokensSentInvalid
-  , nettestScenarioCaps "Sending too many tokens fails" $ do 
+        & expectError errTokensSentInvalid
+  , nettestScenarioCaps "Sending too many tokens fails" $ do
       setup <- doFA2Setup
       let admin ::< alice ::< SNil = sAddresses setup
       let tokenId1 ::< tokenId2 ::< tokenId3 ::< SNil = sTokens setup
       fa2 <- originateFA2 "fa2" setup []
       let fa2Address = toAddress fa2
       swap <- originateOffchainCollections admin fa2Address
-      
+
       withSender admin $ do
         addCollection' (Set.fromList [tokenId1, tokenId2, tokenId3]) swap
-      
-      withSender alice $ 
+
+      withSender alice $
        addOperatorOnTokens' [tokenId1, tokenId2, tokenId3] (toAddress swap) alice fa2
 
       withSender admin $
@@ -437,19 +433,19 @@ swapTokensSentChecks = testGroup "TokensSent"
       let tokensSent = Set.fromList [(initCollectionId , tokenId1), (initCollectionId , tokenId2), (initCollectionId , tokenId3)]
       withSender admin
         (offchainAccept' tokensSent alice swap)
-        & expectError swap errTokensSentInvalid
-  , nettestScenarioCaps "Sending incorrect tokens fails" $ do 
+        & expectError errTokensSentInvalid
+  , nettestScenarioCaps "Sending incorrect tokens fails" $ do
       setup <- doFA2Setup
       let admin ::< alice ::< SNil = sAddresses setup
       let tokenId1 ::< tokenId2 ::< tokenId3 ::< SNil = sTokens setup
       fa2 <- originateFA2 "fa2" setup []
       let fa2Address = toAddress fa2
       swap <- originateOffchainCollections admin fa2Address
-      
+
       withSender admin $ do
         addCollection' (Set.fromList [tokenId1, tokenId2]) swap
-      
-      withSender alice $ 
+
+      withSender alice $
        addOperatorOnTokens' [tokenId1, tokenId2, tokenId3] (toAddress swap) alice fa2
 
       withSender admin $
@@ -461,7 +457,7 @@ swapTokensSentChecks = testGroup "TokensSent"
       let tokensSent = Set.fromList [(initCollectionId , tokenId1), (initCollectionId , tokenId3)]
       withSender admin
         (offchainAccept' tokensSent alice swap)
-        & expectError swap errTokensSentInvalid
+        & expectError errTokensSentInvalid
   ]
 
 swapIdChecks :: TestTree
@@ -478,9 +474,9 @@ swapIdChecks = testGroup "SwapIds"
         addCollection' (Set.fromList [tokenId1]) swap
         addCollection' (Set.fromList [tokenId2]) swap
         addCollection' (Set.fromList [tokenId3]) swap
-      
 
-      withSender alice $ 
+
+      withSender alice $
        addOperatorOnTokens' [tokenId1, tokenId2, tokenId3] (toAddress swap) alice fa2
 
       withSender admin $
@@ -497,11 +493,11 @@ swapIdChecks = testGroup "SwapIds"
         ] $ do
           withSender admin $ do
             (\acceptParam -> offchainAcceptSwapId' acceptParam alice swap) AcceptParam {
-                swapId = Basic.initSwapId , 
+                swapId = Basic.initSwapId ,
                 tokensSent = one $ (initCollectionId, tokenId1)
               }
             (\acceptParam -> offchainAcceptSwapId' acceptParam alice swap) AcceptParam {
-                swapId = Basic.incrementSwapId $ Basic.incrementSwapId Basic.initSwapId , 
+                swapId = Basic.incrementSwapId $ Basic.incrementSwapId Basic.initSwapId ,
                 tokensSent = one $ (incrementCollectionId $ incrementCollectionId $ initCollectionId, tokenId3)
               }
 
@@ -514,26 +510,26 @@ swapIdChecks = testGroup "SwapIds"
       swap <- originateOffchainCollections admin fa2Address
       withSender admin $
         offchainAccept' Set.empty alice swap
-          & expectError swap errSwapNotExist
-      
-      withSender admin 
+          & expectError errSwapNotExist
+
+      withSender admin
         (call swap (Call @"Cancel") Basic.initSwapId
-          & expectError swap errSwapNotExist)
-      
-      withSender admin $ do 
+          & expectError errSwapNotExist)
+
+      withSender admin $ do
         call swap (Call @"Start") $ mkSingleOffer (SwapOffer [] [])
 
         (\acceptParam -> offchainAcceptSwapId' acceptParam alice swap) AcceptParam {
-                swapId = Basic.incrementSwapId Basic.initSwapId , 
+                swapId = Basic.incrementSwapId Basic.initSwapId ,
                 tokensSent = Set.empty
               }
-          & expectError swap errSwapNotExist
+          & expectError errSwapNotExist
 
         call swap (Call @"Cancel") (Basic.incrementSwapId Basic.initSwapId)
-          & expectError swap errSwapNotExist
+          & expectError errSwapNotExist
 
         (\acceptParam -> offchainAcceptSwapId' acceptParam alice swap) AcceptParam {
-                swapId = Basic.initSwapId , 
+                swapId = Basic.initSwapId ,
                 tokensSent = Set.empty
               }
   ]
@@ -553,11 +549,11 @@ authorizationChecks = testGroup "Authorization checks"
         call swap (Call @"Start") $ mkSingleOffer $ SwapOffer [] []
 
       call swap (Call @"Cancel") Basic.initSwapId
-        & expectError swap errNotAdmin
+        & expectError errNotAdmin
 
       withSender alice $
         call swap (Call @"Cancel") Basic.initSwapId
-        & expectError swap errNotAdmin
+        & expectError errNotAdmin
   ]
 
 invalidFA2sChecks :: TestTree
@@ -567,10 +563,9 @@ invalidFA2sChecks = testGroup "Invalid FA2s"
       let admin ::< alice ::< SNil = sAddresses setup
       let tokenId1 ::< SNil = sTokens setup
 
-      fakeFa2 <-
-        TAddress . unTAddress <$>
-        originateSimple "fake-fa2" ([] :: [Integer]) contractConsumer
-      let nonExistingFa2 = TAddress $ unsafeParseAddress "tz1b7p3PPBd3vxmMHZkvtC61C7ttYE6g683F"
+      fakeFa2 <- originateSimple "fake-fa2" ([] :: [Integer]) contractConsumer
+      let nonExistingFa2 = ContractHandler "non-existing FA2"
+            (unsafeParseAddress "tz1b7p3PPBd3vxmMHZkvtC61C7ttYE6g683F")
       let pseudoFa2s = [("fake FA2", fakeFa2), ("non existing FA2", nonExistingFa2)]
 
       for_ pseudoFa2s $ \(desc, fa2) -> do
@@ -587,7 +582,7 @@ invalidFA2sChecks = testGroup "Invalid FA2s"
             { assetsOffered = Basic.tokens $ mkFA2Assets fa2 [(tokenId1, 1)]
             , assetsRequested = []
             })
-            & expectError swap errSwapOfferedFA2Invalid
+            & expectError errSwapOfferedFA2Invalid
 
         comment "Checking requested FA2"
         withSender admin $ do
@@ -598,7 +593,7 @@ invalidFA2sChecks = testGroup "Invalid FA2s"
         let tokensSent = Set.fromList [(initCollectionId , tokenId1)]
         withSender admin
           (offchainAccept' tokensSent alice swap)
-          & expectError swap errSwapRequestedFA2Invalid
+          & expectError errSwapRequestedFA2Invalid
   ]
 ----------------------------------------------------------------------------
 -- Swap + Burn Tests Using normal Accept
@@ -613,9 +608,9 @@ test_Integrational = testGroup "Integrational"
       fa2 <- originateFA2 "fa2" setup []
       let fa2Address = toAddress fa2
       swap <- originateOffchainCollections admin fa2Address
-      withSender alice $ 
+      withSender alice $
         addOperatorOnTokens' [tokenId1, tokenId2, tokenId3, tokenId4, tokenId5] (toAddress swap) alice fa2
-      withSender admin $ 
+      withSender admin $
         addOperatorOnTokens' [adminToken] (toAddress swap) admin fa2
 
       assertingBalanceDeltas fa2
@@ -629,7 +624,7 @@ test_Integrational = testGroup "Integrational"
         , (alice, tokenId2) -: -1
         , (alice, adminToken) -: 10
         ] $ do
-          withSender admin $ do  
+          withSender admin $ do
             addCollection' (Set.fromList [tokenId1, tokenId2, tokenId3, tokenId4, tokenId5]) swap
             addCollection' (Set.fromList [tokenId1, tokenId4, tokenId5]) swap
             call swap (Call @"Start") $ mkSingleOffer SwapOffer
@@ -637,10 +632,10 @@ test_Integrational = testGroup "Integrational"
               , assetsRequested = [initCollectionId, initCollectionId, incrementCollectionId initCollectionId]
               }
           withSender alice $
-            call swap (Call @"Accept") AcceptParam 
+            call swap (Call @"Accept") AcceptParam
               {
-                swapId = Basic.initSwapId , 
-                tokensSent = Set.fromList [(initCollectionId, tokenId1), (initCollectionId, tokenId2), (incrementCollectionId initCollectionId, tokenId5)] 
+                swapId = Basic.initSwapId ,
+                tokensSent = Set.fromList [(initCollectionId, tokenId1), (initCollectionId, tokenId2), (incrementCollectionId initCollectionId, tokenId5)]
               }
   ]
 
@@ -667,7 +662,7 @@ test_IntegrationalWithFA2GlobalOperators = testGroup "Integrational"
         , (alice, tokenId2) -: -1
         , (alice, adminToken) -: 10
         ] $ do
-          withSender admin $ do  
+          withSender admin $ do
             addCollection' (Set.fromList [tokenId1, tokenId2, tokenId3, tokenId4, tokenId5]) swap
             addCollection' (Set.fromList [tokenId1, tokenId4, tokenId5]) swap
             call swap (Call @"Start") $ mkSingleOffer SwapOffer
@@ -675,57 +670,57 @@ test_IntegrationalWithFA2GlobalOperators = testGroup "Integrational"
               , assetsRequested = [initCollectionId, initCollectionId, incrementCollectionId initCollectionId]
               }
           withSender alice $
-            call swap (Call @"Accept") AcceptParam 
+            call swap (Call @"Accept") AcceptParam
               {
-                swapId = Basic.initSwapId  
-              , tokensSent = Set.fromList [(initCollectionId, tokenId1), (initCollectionId, tokenId2), (incrementCollectionId initCollectionId, tokenId5)] 
+                swapId = Basic.initSwapId
+              , tokensSent = Set.fromList [(initCollectionId, tokenId1), (initCollectionId, tokenId2), (incrementCollectionId initCollectionId, tokenId5)]
               }
   ]
 
 ----------------------------------------------------------------------------
--- Admin Checks 
+-- Admin Checks
 ----------------------------------------------------------------------------
 
 
 test_AdminChecks :: TestTree
-test_AdminChecks = do  
+test_AdminChecks = do
   adminOwnershipTransferChecks (\admin -> originateOffchainCollections admin exampleFA2Address)
 
 ----------------------------------------------------------------------------
 -- Helpers
 ----------------------------------------------------------------------------
-addCollection' :: (HasCallStack, MonadNettest caps base m) => Set TokenId -> TAddress OffchainCollectionsEntrypoints -> m ()
+addCollection' :: (HasCallStack, MonadNettest caps base m) => Set TokenId -> ContractHandler OffchainCollectionsEntrypoints st -> m ()
 addCollection' collection contract = call contract (Call @"Add_collection") collection
 
-addCollections' :: (HasCallStack, MonadEmulated caps base m) => [TokenId] -> TAddress OffchainCollectionsEntrypoints -> m [[TokenId]]
+addCollections' :: (HasCallStack, MonadEmulated caps base m) => [TokenId] -> ContractHandler OffchainCollectionsEntrypoints st -> m [[TokenId]]
 addCollections' tokenIds contract = do
   let collections =  map sort (filter (not . null) (filterM (const [True, False]) tokenIds))
-  mapM_ (\collection -> addCollection (Set.fromList collection) contract) collections 
+  mapM_ (\collection -> addCollection (Set.fromList collection) contract) collections
   return collections
 
-addCollection :: (HasCallStack, MonadEmulated caps base m) => Set TokenId -> TAddress OffchainCollectionsEntrypoints -> m ()
+addCollection :: (HasCallStack, MonadEmulated caps base m) => Set TokenId -> ContractHandler OffchainCollectionsEntrypoints st -> m ()
 addCollection collection contract = call contract (Call @"Add_collection") collection
 
-addCollections :: (HasCallStack, MonadEmulated caps base m) => [TokenId] -> TAddress OffchainCollectionsEntrypoints -> m [[TokenId]]
-addCollections tokenIds contract = do 
+addCollections :: (HasCallStack, MonadEmulated caps base m) => [TokenId] -> ContractHandler OffchainCollectionsEntrypoints st -> m [[TokenId]]
+addCollections tokenIds contract = do
   let collections = map sort (filter (not . null) (filterM (const [True, False]) tokenIds))
-  mapM_ (\collection -> addCollection (Set.fromList collection) contract) collections 
-  return collections 
+  mapM_ (\collection -> addCollection (Set.fromList collection) contract) collections
+  return collections
 
-addOperatorOnTokens :: (HasCallStack, MonadEmulated caps base m) => [TokenId] -> Address -> Address -> TAddress FA2.FA2SampleParameter -> m() 
-addOperatorOnTokens tokens operator owner fa2 = 
+addOperatorOnTokens :: (HasCallStack, MonadEmulated caps base m) => [TokenId] -> Address -> Address -> ContractHandler FA2.FA2SampleParameter st -> m()
+addOperatorOnTokens tokens operator owner fa2 =
   call fa2 (Call @"Update_operators") operatorParamList
-  where 
+  where
     operatorParamList = map (\token -> FA2I.AddOperator FA2I.OperatorParam
               { opOwner = owner
               , opOperator = toAddress operator
               , opTokenId = token
               }) tokens
 
-addOperatorOnTokens' :: (HasCallStack, MonadNettest caps base m) => [TokenId] -> Address -> Address -> TAddress FA2.FA2SampleParameter  -> m() 
-addOperatorOnTokens' tokens operator owner fa2 = 
+addOperatorOnTokens' :: (HasCallStack, MonadNettest caps base m) => [TokenId] -> Address -> Address -> ContractHandler FA2.FA2SampleParameter st -> m()
+addOperatorOnTokens' tokens operator owner fa2 =
   call fa2 (Call @"Update_operators") operatorParamList
-  where 
+  where
     operatorParamList = map (\token -> FA2I.AddOperator FA2I.OperatorParam
               { opOwner = owner
               , opOperator = toAddress operator
@@ -733,56 +728,56 @@ addOperatorOnTokens' tokens operator owner fa2 =
               }) tokens
 
 --N addresses accept all N assets in a sale conseutively, and then all N are confirmed
-offchainAcceptAllConsecutive :: (HasCallStack, MonadEmulated caps base m) => Set (CollectionId, TokenId) -> [Address] -> TAddress OffchainCollectionsEntrypoints -> m ()
+offchainAcceptAllConsecutive :: (HasCallStack, MonadEmulated caps base m) => Set (CollectionId, TokenId) -> [Address] -> ContractHandler OffchainCollectionsEntrypoints st -> m ()
 offchainAcceptAllConsecutive tokensSent addresses contract = do
   forM_ addresses $ \buyer -> do
       offchainAccept tokensSent buyer contract
 
-offchainAcceptBatch :: (HasCallStack, MonadEmulated caps base m) => AcceptParam -> [Address] -> TAddress OffchainCollectionsEntrypoints  -> m ()
+offchainAcceptBatch :: (HasCallStack, MonadEmulated caps base m) => AcceptParam -> [Address] -> ContractHandler OffchainCollectionsEntrypoints st -> m ()
 offchainAcceptBatch acceptParam buyers contract = do
   param <- forM buyers $ \buyer -> do
     buyerPK <- getPublicKey buyer
     unsigned <- mkPermitToSign acceptParam contract
     signature <- signBytes unsigned buyer
-    return OffchainAcceptParam { 
+    return OffchainAcceptParam {
         acceptParam = acceptParam
       , permit = Permit
           {
             signerKey = buyerPK
           , signature = signature
-          } 
-      } 
-  call contract (Call @"Offchain_accept") (toList param) 
+          }
+      }
+  call contract (Call @"Offchain_accept") (toList param)
 
-mkPermitToForge :: (HasCallStack, MonadEmulated caps base m) => AcceptParam -> TAddress OffchainCollectionsEntrypoints -> m (ByteString, PublicKey)
-mkPermitToForge acceptParam contract = do 
+mkPermitToForge :: (HasCallStack, MonadEmulated caps base m) => AcceptParam -> ContractHandler OffchainCollectionsEntrypoints st -> m (ByteString, PublicKey)
+mkPermitToForge acceptParam contract = do
   aliasAddress <- newAddress "forged"
   aliasPK <- getPublicKey aliasAddress
-  unsignedPermit <- mkPermitToSign acceptParam contract 
+  unsignedPermit <- mkPermitToSign acceptParam contract
   pure (unsignedPermit, aliasPK)
 
-mkPermitToSign :: (HasCallStack, MonadEmulated caps base m) => AcceptParam -> TAddress OffchainCollectionsEntrypoints -> m ByteString
-mkPermitToSign acceptParam contract = do 
+mkPermitToSign :: (HasCallStack, MonadEmulated caps base m) => AcceptParam -> ContractHandler OffchainCollectionsEntrypoints st -> m ByteString
+mkPermitToSign acceptParam contract = do
   marketplaceChainId <- getChainId
   let unsigned = packValue' $ toVal ((marketplaceChainId, contractAddress), (0 :: Natural, acceptParamHash))
   pure unsigned
   where acceptParamHash = blake2b $ packValue' $ toVal acceptParam
         contractAddress = toAddress contract
 
-mkPermitToSign' :: (HasCallStack, MonadNettest caps base m) => AcceptParam -> TAddress OffchainCollectionsEntrypoints -> m ByteString
-mkPermitToSign' acceptParam contract = do 
+mkPermitToSign' :: (HasCallStack, MonadNettest caps base m) => AcceptParam -> ContractHandler OffchainCollectionsEntrypoints st -> m ByteString
+mkPermitToSign' acceptParam contract = do
   marketplaceChainId <- getChainId
   let unsigned = packValue' $ toVal ((marketplaceChainId, contractAddress), (0 :: Natural, acceptParamHash))
   pure unsigned
   where acceptParamHash = blake2b $ packValue' $ toVal acceptParam
         contractAddress = toAddress contract
 
-offchainAcceptSwapId :: (HasCallStack, MonadEmulated caps base m) => AcceptParam -> Address -> TAddress OffchainCollectionsEntrypoints -> m ()
+offchainAcceptSwapId :: (HasCallStack, MonadEmulated caps base m) => AcceptParam -> Address -> ContractHandler OffchainCollectionsEntrypoints st -> m ()
 offchainAcceptSwapId acceptParam buyer contract = do
   buyerPK <- getPublicKey buyer
   unsigned <- mkPermitToSign acceptParam contract
-  signature <- signBytes unsigned buyer 
-  call contract (Call @"Offchain_accept") 
+  signature <- signBytes unsigned buyer
+  call contract (Call @"Offchain_accept")
     [OffchainAcceptParam
       {
         acceptParam = acceptParam
@@ -790,16 +785,16 @@ offchainAcceptSwapId acceptParam buyer contract = do
           {
             signerKey = buyerPK
           , signature = signature
-          } 
+          }
       }
     ]
 
-offchainAcceptSwapId' :: (HasCallStack, MonadNettest caps base m) => AcceptParam -> Address -> TAddress OffchainCollectionsEntrypoints -> m ()
+offchainAcceptSwapId' :: (HasCallStack, MonadNettest caps base m) => AcceptParam -> Address -> ContractHandler OffchainCollectionsEntrypoints st -> m ()
 offchainAcceptSwapId' acceptParam buyer contract = do
   buyerPK <- getPublicKey buyer
   unsigned <- mkPermitToSign' acceptParam contract
-  signature <- signBytes unsigned buyer 
-  call contract (Call @"Offchain_accept") 
+  signature <- signBytes unsigned buyer
+  call contract (Call @"Offchain_accept")
     [OffchainAcceptParam
       {
         acceptParam = acceptParam
@@ -807,27 +802,27 @@ offchainAcceptSwapId' acceptParam buyer contract = do
           {
             signerKey = buyerPK
           , signature = signature
-          } 
+          }
       }
     ]
 
-offchainAccept :: (HasCallStack, MonadEmulated caps base m) => Set (CollectionId, TokenId) -> Address -> TAddress OffchainCollectionsEntrypoints -> m ()
+offchainAccept :: (HasCallStack, MonadEmulated caps base m) => Set (CollectionId, TokenId) -> Address -> ContractHandler OffchainCollectionsEntrypoints st -> m ()
 offchainAccept tokensSent = offchainAcceptSwapId AcceptParam {
-    swapId = Basic.initSwapId, 
+    swapId = Basic.initSwapId,
     tokensSent = tokensSent
   }
 
-offchainAccept' :: (HasCallStack, MonadNettest caps base m) => Set (CollectionId, TokenId) -> Address -> TAddress OffchainCollectionsEntrypoints -> m ()
+offchainAccept' :: (HasCallStack, MonadNettest caps base m) => Set (CollectionId, TokenId) -> Address -> ContractHandler OffchainCollectionsEntrypoints st -> m ()
 offchainAccept' tokensSent = offchainAcceptSwapId' AcceptParam {
-    swapId = Basic.initSwapId, 
+    swapId = Basic.initSwapId,
     tokensSent = tokensSent
   }
 
-offchainAcceptForged :: (HasCallStack, MonadEmulated caps base m) => AcceptParam -> Address -> TAddress OffchainCollectionsEntrypoints -> m ByteString
+offchainAcceptForged :: (HasCallStack, MonadEmulated caps base m) => AcceptParam -> Address -> ContractHandler OffchainCollectionsEntrypoints st -> m ByteString
 offchainAcceptForged acceptParam buyer contract = do
   (unsigned, forgedPK) <- mkPermitToForge acceptParam contract
-  signature <- signBytes unsigned buyer 
-  (\() -> unsigned) <$> call contract (Call @"Offchain_accept") 
+  signature <- signBytes unsigned buyer
+  (\() -> unsigned) <$> call contract (Call @"Offchain_accept")
     [OffchainAcceptParam
       {
         acceptParam = acceptParam
@@ -835,13 +830,13 @@ offchainAcceptForged acceptParam buyer contract = do
           {
             signerKey = forgedPK
           , signature = signature
-          } 
+          }
       }
-    ] 
+    ]
 
 assertingBurnAddressStatus
   :: (MonadEmulated caps base m, HasCallStack)
-  => TAddress b
+  => ContractHandler b CollectionsStorage
   -> m a
   -> (Address -> Address -> m ())
   -> m a
@@ -852,22 +847,21 @@ assertingBurnAddressStatus swapContract action changedStatus = do
   initBurnAddress `changedStatus` finalBurnAddress
   return res
     where
-      getBurnAddress c = do 
-        storage <- fromVal @CollectionsStorage <$> getStorage' c
-        pure $ burnAddress storage
+      getBurnAddress c =
+        burnAddress <$> getStorage' c
 
-assertingBurnAddressUnchanged 
+assertingBurnAddressUnchanged
   :: (MonadEmulated caps base m, HasCallStack)
-  => TAddress b
+  => ContractHandler b CollectionsStorage
   -> m a
-  -> m a 
-assertingBurnAddressUnchanged swapContract action = 
+  -> m a
+assertingBurnAddressUnchanged swapContract action =
    assertingBurnAddressStatus swapContract action (@==)
 
 assertingBurnAddressChanged
   :: (MonadEmulated caps base m, HasCallStack)
-  => TAddress b
+  => ContractHandler b CollectionsStorage
   -> m a
-  -> m a 
-assertingBurnAddressChanged swapContract action = 
+  -> m a
+assertingBurnAddressChanged swapContract action =
    assertingBurnAddressStatus swapContract action (@/=)

--- a/packages/minter-contracts/test-hs/Test/Swaps/SwapPermit.hs
+++ b/packages/minter-contracts/test-hs/Test/Swaps/SwapPermit.hs
@@ -7,9 +7,9 @@ import qualified Data.Sized as Sized (toList)
 
 import Morley.Nettest
 
-import Hedgehog (Property, property, forAll)
+import Hedgehog (Property, forAll, property)
 
-import Michelson.Interpret.Pack 
+import Michelson.Interpret.Pack
 
 import qualified Lorentz.Contracts.Spec.FA2Interface as FA2I
 import Lorentz.Contracts.Swaps.Allowlisted
@@ -31,23 +31,24 @@ hprop_Sending_fake_permit_to_offchain_accept_fails =
       let admin ::< alice ::< SNil = sAddresses setup
       let tokenId1 ::< SNil = sTokens setup
       swap <- originateOffchainSwap admin
-      swapId <- (\(SwapId n) -> n) . 
-                nextSwapId . 
+      swapId <- (\(SwapId n) -> n) .
+                nextSwapId .
                 swapStorage <$>
-                fromVal @AllowlistedSwapStorage <$> 
-                getStorage' swap 
+                getStorage' swap
       fa2 <- originateFA2 "fa2" setup [swap]
       withSender admin $
         call swap (Call @"Update_allowed") (mkAllowlistSimpleParam [fa2])
-      withSender admin $ do 
+      withSender admin $ do
         call swap (Call @"Start") $ mkSingleOffer SwapOffer
           { assetsOffered = []
           , assetsRequested = [mkFA2Assets fa2 [(tokenId1, 1)]]
           }
       missignedBytes <- fst <$> mkPermitToForge swapId swap
       withSender admin $ do
-        offchainAcceptForged alice swap `expectFailure` failedWith swap
-          ([mt|MISSIGNED|], missignedBytes)
+        offchainAcceptForged alice swap
+          & expectTransferFailure
+            [failedWith $ constant ([mt|MISSIGNED|], missignedBytes)]
+
 
 hprop_Offchain_accept_not_admin_submitted_fails :: Property
 hprop_Offchain_accept_not_admin_submitted_fails =
@@ -60,14 +61,14 @@ hprop_Offchain_accept_not_admin_submitted_fails =
       fa2 <- originateFA2 "fa2" setup [swap]
       withSender admin $
         call swap (Call @"Update_allowed") (mkAllowlistSimpleParam [fa2])
-      withSender admin $ do 
+      withSender admin $ do
         call swap (Call @"Start") $ mkSingleOffer SwapOffer
           { assetsOffered = []
           , assetsRequested = [mkFA2Assets fa2 [(tokenId1, 1)]]
           }
       withSender alice $ do
-        offchainAccept alice swap `expectFailure` failedWith swap
-          errNotAdmin
+        offchainAccept alice swap
+          & expectTransferFailure [failedWith $ constant errNotAdmin]
 
 hprop_Consecutive_offchain_accept_equals_iterative_accept :: Property
 hprop_Consecutive_offchain_accept_equals_iterative_accept =
@@ -76,7 +77,7 @@ hprop_Consecutive_offchain_accept_equals_iterative_accept =
       clevelandProp $ do
         setup <- doFA2Setup @("addresses" :# 50) @("tokens" :# 2)
         let admin1 ::< admin2 ::< remainingAddresses = sAddresses setup
-        let addresses = take (fromIntegral numOffers) (Sized.toList remainingAddresses) 
+        let addresses = take (fromIntegral numOffers) (Sized.toList remainingAddresses)
         let tokenId1 ::< tokenId2 ::< SNil = sTokens setup
         swap1 <- originateOffchainSwap admin1
         swap2 <- originateOffchainSwap admin2
@@ -86,12 +87,12 @@ hprop_Consecutive_offchain_accept_equals_iterative_accept =
           call swap1 (Call @"Update_allowed") (mkAllowlistSimpleParam [fa2_1])
         withSender admin2 $
           call swap2 (Call @"Update_allowed") (mkAllowlistSimpleParam [fa2_2])
-        withSender admin1 $ do 
+        withSender admin1 $ do
           call swap1 (Call @"Start") $ mkNOffers numOffers SwapOffer
                { assetsOffered = [mkFA2Assets fa2_1 [(tokenId1, token1Offer), (tokenId2, token2Offer)]]
                , assetsRequested = [mkFA2Assets fa2_1 [(tokenId1, token1Request), (tokenId2, token2Request)]]
                }
-        withSender admin2 $ do 
+        withSender admin2 $ do
           call swap2 (Call @"Start") $ mkNOffers numOffers SwapOffer
                { assetsOffered = [mkFA2Assets fa2_2 [(tokenId1, token1Offer), (tokenId2, token2Offer)]]
                , assetsRequested = [mkFA2Assets fa2_2 [(tokenId1, token1Request), (tokenId2, token2Request)]]
@@ -100,15 +101,9 @@ hprop_Consecutive_offchain_accept_equals_iterative_accept =
           offchainAcceptAllConsecutive addresses swap1
         withSender admin2 $ do
           offchainAcceptBatch addresses swap2
-      
-        swapStorage1 <-  toVal <$>
-                         swapStorage <$>
-                         fromVal @AllowlistedSwapStorage <$> 
-                         getStorage' swap1
-        swapStorage2 <-  toVal <$>
-                         swapStorage <$>
-                         fromVal @AllowlistedSwapStorage <$> 
-                         getStorage' swap2
+
+        swapStorage1 <- toVal . swapStorage <$> getStorage' swap1
+        swapStorage2 <- toVal . swapStorage <$> getStorage' swap2
         swapStorage1 @== swapStorage2
 
 hprop_Accepting_with_zero_balance_fails :: Property
@@ -123,8 +118,8 @@ hprop_Accepting_with_zero_balance_fails =
           withSender admin $
             call swap (Call @"Update_allowed") (mkAllowlistSimpleParam [fa2])
           addressWithZeroBalance <- newAddress "test"
-          withSender addressWithZeroBalance $ 
-            call fa2 (Call @"Update_operators")     
+          withSender addressWithZeroBalance $
+            call fa2 (Call @"Update_operators")
               [
                 FA2I.AddOperator FA2I.OperatorParam
                   { opOwner = addressWithZeroBalance
@@ -139,23 +134,24 @@ hprop_Accepting_with_zero_balance_fails =
               }
           withSender admin
             (offchainAccept addressWithZeroBalance swap
-              `expectFailure` failedWith fa2 (errSwapRequestedFA2BalanceInvalid 5 0))  
+              & expectTransferFailure
+                [failedWith $ constant (errSwapRequestedFA2BalanceInvalid 5 0)])
 
 hprop_Start_callable_by_admin_only :: Property
-hprop_Start_callable_by_admin_only = 
+hprop_Start_callable_by_admin_only =
   property $ do
-   TestData{numOffers, token1Offer, token2Offer, token1Request, token2Request} <- forAll genTestData 
+   TestData{numOffers, token1Offer, token2Offer, token1Request, token2Request} <- forAll genTestData
    clevelandProp $ do
      setup <- doFA2Setup
      let admin ::< nonAdmin ::< SNil = sAddresses setup
      let tokenId1 ::< tokenId2 ::< SNil = sTokens setup
      swap <- originateOffchainSwap admin
      fa2 <- originateFA2 "fa2" setup [swap]
-     withSender nonAdmin 
+     withSender nonAdmin
        (call swap (Call @"Start") (mkNOffers numOffers SwapOffer
          { assetsOffered = [mkFA2Assets fa2 [(tokenId1, token1Offer), (tokenId2, token2Offer)]]
          , assetsRequested = [mkFA2Assets fa2 [(tokenId1, token1Request), (tokenId2, token2Request)]]
-         }) & expectError swap errNotAdmin)
+         }) & expectError errNotAdmin)
 
 
 ----------------------------------------------------------------------------
@@ -163,49 +159,49 @@ hprop_Start_callable_by_admin_only =
 ----------------------------------------------------------------------------
 
 -- N addresses accept all N assets in a sale conseutively, and then all N are confirmed
-offchainAcceptAllConsecutive :: (HasCallStack, MonadEmulated caps base m) => [Address] -> TAddress PermitSwapEntrypoints -> m ()
+offchainAcceptAllConsecutive :: (HasCallStack, MonadEmulated caps base m) => [Address] -> ContractHandler PermitSwapEntrypoints st -> m ()
 offchainAcceptAllConsecutive addresses contract = do
   forM_ addresses $ \buyer -> do
       offchainAccept buyer contract
 
-offchainAcceptBatch :: (HasCallStack, MonadEmulated caps base m) => [Address] -> TAddress PermitSwapEntrypoints -> m ()
+offchainAcceptBatch :: (HasCallStack, MonadEmulated caps base m) => [Address] -> ContractHandler PermitSwapEntrypoints st -> m ()
 offchainAcceptBatch buyers contract = do
   param <- forM buyers $ \buyer -> do
     buyerPK <- getPublicKey buyer
     unsigned <- mkPermitToSign swapId contract
     signature <- signBytes unsigned buyer
-    return OffchainAcceptParam { 
+    return OffchainAcceptParam {
         swapId = swapId
       , permit = Permit
           {
             signerKey = buyerPK
           , signature = signature
-          } 
-      } 
-  call contract (Call @"Offchain_accept") (toList param) 
+          }
+      }
+  call contract (Call @"Offchain_accept") (toList param)
   where swapId = 1
 
-mkPermitToForge :: (HasCallStack, MonadEmulated caps base m) => Natural -> TAddress PermitSwapEntrypoints -> m (ByteString, PublicKey)
-mkPermitToForge swapId contract = do 
+mkPermitToForge :: (HasCallStack, MonadEmulated caps base m) => Natural -> ContractHandler PermitSwapEntrypoints st -> m (ByteString, PublicKey)
+mkPermitToForge swapId contract = do
   aliasAddress <- newAddress "forged"
   aliasPK <- getPublicKey aliasAddress
-  unsignedPermit <- mkPermitToSign swapId contract 
+  unsignedPermit <- mkPermitToSign swapId contract
   pure (unsignedPermit, aliasPK)
 
-mkPermitToSign :: (HasCallStack, MonadEmulated caps base m) => Natural -> TAddress PermitSwapEntrypoints -> m ByteString
-mkPermitToSign swapId contract = do 
+mkPermitToSign :: (HasCallStack, MonadEmulated caps base m) => Natural -> ContractHandler PermitSwapEntrypoints st -> m ByteString
+mkPermitToSign swapId contract = do
   marketplaceChainId <- getChainId
   let unsigned = packValue' $ toVal ((marketplaceChainId, contractAddress), (0 :: Natural, swapIdHash))
   pure unsigned
-  where swapIdHash = blake2b $ packValue' $ toVal swapId 
+  where swapIdHash = blake2b $ packValue' $ toVal swapId
         contractAddress = toAddress contract
 
-offchainAccept :: (HasCallStack, MonadEmulated caps base m) => Address -> TAddress PermitSwapEntrypoints -> m ()
+offchainAccept :: (HasCallStack, MonadEmulated caps base m) => Address -> ContractHandler PermitSwapEntrypoints st -> m ()
 offchainAccept buyer contract = do
   buyerPK <- getPublicKey buyer
   unsigned <- mkPermitToSign swapId contract
-  signature <- signBytes unsigned buyer 
-  call contract (Call @"Offchain_accept") 
+  signature <- signBytes unsigned buyer
+  call contract (Call @"Offchain_accept")
     [OffchainAcceptParam
       {
         swapId = swapId
@@ -213,16 +209,16 @@ offchainAccept buyer contract = do
           {
             signerKey = buyerPK
           , signature = signature
-          } 
+          }
       }
     ]
   where swapId = 1
 
-offchainAcceptForged :: (HasCallStack, MonadEmulated caps base m) => Address -> TAddress PermitSwapEntrypoints -> m ByteString
+offchainAcceptForged :: (HasCallStack, MonadEmulated caps base m) => Address -> ContractHandler PermitSwapEntrypoints st -> m ByteString
 offchainAcceptForged buyer contract = do
   (unsigned, forgedPK) <- mkPermitToForge swapId contract
-  signature <- signBytes unsigned buyer 
-  (\() -> unsigned) <$> call contract (Call @"Offchain_accept") 
+  signature <- signBytes unsigned buyer
+  (\() -> unsigned) <$> call contract (Call @"Offchain_accept")
     [OffchainAcceptParam
       {
         swapId = swapId
@@ -230,7 +226,7 @@ offchainAcceptForged buyer contract = do
           {
             signerKey = forgedPK
           , signature = signature
-          } 
+          }
       }
-    ] 
+    ]
   where swapId = 1

--- a/packages/minter-contracts/test-hs/Test/Swaps/Util.hs
+++ b/packages/minter-contracts/test-hs/Test/Swaps/Util.hs
@@ -22,53 +22,51 @@ module Test.Swaps.Util
 
 import qualified Lorentz.Contracts.Spec.FA2Interface as FA2
 import Lorentz.Value
-import qualified Michelson.Typed as T
 import Morley.Nettest
+
+import Lorentz.Contracts.Swaps.Contracts
 
 import Lorentz.Contracts.Swaps.Allowlisted
 import Lorentz.Contracts.Swaps.Basic
 import Lorentz.Contracts.Swaps.SwapPermit
 
+import qualified Lorentz.Contracts.Swaps.AllowlistedFee as AllowlistedFee
 import Lorentz.Contracts.Swaps.Burn
-import Lorentz.Contracts.Swaps.AllowlistedFee
 
 import Lorentz.Contracts.Swaps.Collections
 import Lorentz.Contracts.Swaps.SwapPermitBurnFee
+
 import Test.Util
 
 -- | Originate the swaps contract.
 originateSwap
   :: MonadNettest caps base m
-  => m (TAddress Lorentz.Contracts.Swaps.Basic.SwapEntrypoints)
-originateSwap = do
-  TAddress <$> originateUntypedSimple "swaps"
-    (T.untypeValue $ T.toVal Lorentz.Contracts.Swaps.Basic.initSwapStorage)
-    (T.convertContract swapsContract)
+  => m (ContractHandler SwapEntrypoints SwapStorage)
+originateSwap =
+  originateSimple "swaps" initSwapStorage swapsContract
 
 -- | Originate the allowlisted swaps contract.
 originateAllowlistedSwap
   :: MonadNettest caps base m
   => Address
-  -> m (TAddress AllowlistedSwapEntrypoints)
-originateAllowlistedSwap admin = do
-  TAddress <$> originateUntypedSimple "swaps"
-    (T.untypeValue $ T.toVal $ initAllowlistedSwapStorage admin)
-    (T.convertContract allowlistedSwapsContract)
+  -> m (ContractHandler AllowlistedSwapEntrypoints AllowlistedSwapStorage)
+originateAllowlistedSwap admin =
+  originateSimple "swaps" (initAllowlistedSwapStorage admin) allowlistedSwapsContract
 
 -- | Originate the allowlisted burn swaps contract.
 originateAllowlistedBurnSwap
   :: MonadNettest caps base m
   => Address
-  -> m (TAddress AllowlistedBurnSwapEntrypoints)
+  -> m (ContractHandler AllowlistedBurnSwapEntrypoints AllowlistedBurnSwapStorage)
 originateAllowlistedBurnSwap admin = do
-  TAddress <$> originateUntypedSimple "swaps"
-    (T.untypeValue $ T.toVal $ initAllowlistedBurnSwapStorage admin)
-    (T.convertContract allowlistedBurnSwapsContract)
+  originateSimple "swaps"
+    (initAllowlistedBurnSwapStorage admin)
+    allowlistedBurnSwapsContract
 
 -- | Originate the allowlisted burn swaps contract and admin for it.
 originateAllowlistedBurnSwapWithAdmin
   :: MonadNettest caps base m
-  => m (TAddress AllowlistedBurnSwapEntrypoints, Address)
+  => m (ContractHandler AllowlistedBurnSwapEntrypoints AllowlistedBurnSwapStorage, Address)
 originateAllowlistedBurnSwapWithAdmin =
   originateWithAdmin originateAllowlistedBurnSwap
 
@@ -77,16 +75,16 @@ originateAllowlistedBurnSwapWithAdmin =
 originateChangeBurnAddressSwap
   :: MonadNettest caps base m
   => Address
-  -> m (TAddress ChangeBurnAddressSwapEntrypoints)
+  -> m (ContractHandler ChangeBurnAddressSwapEntrypoints AllowlistedBurnSwapStorage)
 originateChangeBurnAddressSwap admin = do
-  TAddress <$> originateUntypedSimple "swaps"
-    (T.untypeValue $ T.toVal $ initAllowlistedBurnSwapStorage admin)
-    (T.convertContract changeBurnAddressSwapsContract)
+  originateSimple "swaps"
+    (initAllowlistedBurnSwapStorage admin)
+    changeBurnAddressSwapsContract
 
 -- | Originate the allowlisted burn swaps contract and admin for it.
 originateChangeBurnAddressSwapWithAdmin
   :: MonadNettest caps base m
-  => m (TAddress ChangeBurnAddressSwapEntrypoints, Address)
+  => m (ContractHandler ChangeBurnAddressSwapEntrypoints AllowlistedBurnSwapStorage, Address)
 originateChangeBurnAddressSwapWithAdmin =
   originateWithAdmin originateChangeBurnAddressSwap
 
@@ -94,7 +92,7 @@ originateChangeBurnAddressSwapWithAdmin =
 -- | Originate the allowlisted burn swaps contract and admin for it.
 originateOffchainSwapBurnFeeWithAdmin
   :: MonadNettest caps base m
-  => m (TAddress PermitSwapBurnFeeEntrypoints, Address)
+  => m (ContractHandler PermitSwapBurnFeeEntrypoints AllowlistedBurnSwapFeeStorage, Address)
 originateOffchainSwapBurnFeeWithAdmin =
   originateWithAdmin originateOffchainSwapBurnFee
 
@@ -103,16 +101,18 @@ originateOffchainSwapBurnFeeWithAdmin =
 originateAllowlistedFeeSwap
   :: MonadNettest caps base m
   => Address
-  -> m (TAddress Lorentz.Contracts.Swaps.AllowlistedFee.AllowlistedFeeSwapEntrypoints)
+  -> m $ ContractHandler
+      AllowlistedFee.AllowlistedFeeSwapEntrypoints
+      AllowlistedFee.AllowlistedFeeSwapStorage
 originateAllowlistedFeeSwap admin = do
-  TAddress <$> originateUntypedSimple "swaps"
-    (T.untypeValue $ T.toVal $ initAllowlistedFeeSwapStorage admin)
-    (T.convertContract allowlistedFeeSwapsContract)
+  originateSimple "swaps"
+    (AllowlistedFee.initAllowlistedFeeSwapStorage admin)
+    allowlistedFeeSwapsContract
 
 -- | Originate the allowlisted swaps contract and admin for it.
 originateAllowlistedSwapWithAdmin
   :: MonadNettest caps base m
-  => m (TAddress AllowlistedSwapEntrypoints, Address)
+  => m (ContractHandler AllowlistedSwapEntrypoints AllowlistedSwapStorage, Address)
 originateAllowlistedSwapWithAdmin =
   originateWithAdmin originateAllowlistedSwap
 
@@ -120,49 +120,49 @@ originateAllowlistedSwapWithAdmin =
 originateOffchainSwap
   :: MonadNettest caps base m
   => Address
-  -> m (TAddress PermitSwapEntrypoints)
+  -> m (ContractHandler PermitSwapEntrypoints AllowlistedSwapStorage)
 originateOffchainSwap admin = do
-  TAddress <$> originateUntypedSimple "swaps"
-    (T.untypeValue $ T.toVal $ initAllowlistedSwapStorage admin)
-    (T.convertContract allowlistedSwapsPermitContract)
+  originateSimple "swaps"
+    (initAllowlistedSwapStorage admin)
+    allowlistedSwapsPermitContract
 
 -- | Originate the offchain collections contract
 originateOffchainCollections
   :: MonadNettest caps base m
   => Address
   -> Address
-  -> m (TAddress OffchainCollectionsEntrypoints)
+  -> m (ContractHandler OffchainCollectionsEntrypoints CollectionsStorage)
 originateOffchainCollections admin fa2 = do
-  TAddress <$> originateUntypedSimple "swaps"
-    (T.untypeValue $ T.toVal $ initCollectionsStorage admin fa2)
-    (T.convertContract offchainCollectionsContract)
+  originateSimple "swaps"
+    (initCollectionsStorage admin fa2)
+    offchainCollectionsContract
 
 
 -- | Originate the swaps contract with offchain_accept entrypoint.
 originateOffchainSwapBurnFee
   :: MonadNettest caps base m
   => Address
-  -> m (TAddress PermitSwapBurnFeeEntrypoints)
+  -> m (ContractHandler PermitSwapBurnFeeEntrypoints AllowlistedBurnSwapFeeStorage)
 originateOffchainSwapBurnFee admin = do
-  TAddress <$> originateUntypedSimple "swaps"
-    (T.untypeValue $ T.toVal $ initAllowlistedBurnSwapFeeStorage admin)
-    (T.convertContract allowlistedSwapsPermitBurnFeeContract)
+  originateSimple "swaps"
+    (initAllowlistedBurnSwapFeeStorage admin)
+    allowlistedSwapsPermitBurnFeeContract
 
 -- | Originate the allowlisted swaps contract and admin for it.
 originateOffchainSwapWithAdmin
   :: MonadNettest caps base m
-  => m (TAddress PermitSwapEntrypoints, Address)
+  => m (ContractHandler PermitSwapEntrypoints AllowlistedSwapStorage, Address)
 originateOffchainSwapWithAdmin =
   originateWithAdmin originateOffchainSwap
 
 ---- | Originate the offchain collections contract
 --originateOffchainCollectionsWithAdmin
 --  :: MonadNettest caps base m
---  => m (TAddress OffchainCollectionsEntrypoints, Address)
---originateOffchainCollectionsWithAdmin = 
+--  => m (ContractHandler OffchainCollectionsEntrypoints CollectionsStorage, Address)
+--originateOffchainCollectionsWithAdmin =
 --  originateWithAdmin originateOffchainCollections
 
 -- | Construct 'FA2Assets' from a simplified representation.
-mkFA2Assets :: TAddress fa2Param -> [(FA2.TokenId, Natural)] -> FA2Assets
+mkFA2Assets :: ContractHandler fa2Param fa2Storage -> [(FA2.TokenId, Natural)] -> FA2Assets
 mkFA2Assets addr tokens =
   FA2Assets (toAddress addr) (uncurry FA2Token <$> tokens)


### PR DESCRIPTION
Use the recent Cleveland version where `ToT` and `fromVal` things are not necessary anymore.

`embedContract` has shown some limitations so I replaced it with `importContract`. One issue with this is that now 20% of CPU time is spent in contract parser, probably we should consider caching all the ever imported contracts.