### PR TITLE
changed bid raise logic and updates tests

### DIFF
--- a/packages/minter-contracts/bin/english_auction_tez.tz
+++ b/packages/minter-contracts/bin/english_auction_tez.tz
@@ -460,7 +460,7 @@
                          DIG 3 ;
                          COMPARE ;
                          GE ;
-                         OR ;
+                         AND ;
                          OR ;
                          NOT ;
                          IF { NOW ;

--- a/packages/minter-contracts/bin/english_auction_tez_allowlisted.tz
+++ b/packages/minter-contracts/bin/english_auction_tez_allowlisted.tz
@@ -460,7 +460,7 @@
                          DIG 3 ;
                          COMPARE ;
                          GE ;
-                         OR ;
+                         AND ;
                          OR ;
                          NOT ;
                          IF { NOW ;

--- a/packages/minter-contracts/bin/english_auction_tez_allowlisted_token.tz
+++ b/packages/minter-contracts/bin/english_auction_tez_allowlisted_token.tz
@@ -466,7 +466,7 @@
                          DIG 3 ;
                          COMPARE ;
                          GE ;
-                         OR ;
+                         AND ;
                          OR ;
                          NOT ;
                          IF { NOW ;

--- a/packages/minter-contracts/bin/english_auction_tez_allowlisted_token_cancel_only_admin.tz
+++ b/packages/minter-contracts/bin/english_auction_tez_allowlisted_token_cancel_only_admin.tz
@@ -466,7 +466,7 @@
                          DIG 3 ;
                          COMPARE ;
                          GE ;
-                         OR ;
+                         AND ;
                          OR ;
                          NOT ;
                          IF { NOW ;

--- a/packages/minter-contracts/bin/english_auction_tez_cancel_only_admin.tz
+++ b/packages/minter-contracts/bin/english_auction_tez_cancel_only_admin.tz
@@ -460,7 +460,7 @@
                          DIG 3 ;
                          COMPARE ;
                          GE ;
-                         OR ;
+                         AND ;
                          OR ;
                          NOT ;
                          IF { NOW ;

--- a/packages/minter-contracts/bin/english_auction_tez_fixed_fee.tz
+++ b/packages/minter-contracts/bin/english_auction_tez_fixed_fee.tz
@@ -460,7 +460,7 @@
                          DIG 3 ;
                          COMPARE ;
                          GE ;
-                         OR ;
+                         AND ;
                          OR ;
                          NOT ;
                          IF { NOW ;

--- a/packages/minter-contracts/bin/english_auction_tez_fixed_fee_allowlisted.tz
+++ b/packages/minter-contracts/bin/english_auction_tez_fixed_fee_allowlisted.tz
@@ -461,7 +461,7 @@
                          DIG 3 ;
                          COMPARE ;
                          GE ;
-                         OR ;
+                         AND ;
                          OR ;
                          NOT ;
                          IF { NOW ;

--- a/packages/minter-contracts/bin/english_auction_tez_fixed_fee_allowlisted_token.tz
+++ b/packages/minter-contracts/bin/english_auction_tez_fixed_fee_allowlisted_token.tz
@@ -467,7 +467,7 @@
                          DIG 3 ;
                          COMPARE ;
                          GE ;
-                         OR ;
+                         AND ;
                          OR ;
                          NOT ;
                          IF { NOW ;

--- a/packages/minter-contracts/bin/english_auction_tez_offchain_bid.tz
+++ b/packages/minter-contracts/bin/english_auction_tez_offchain_bid.tz
@@ -480,7 +480,7 @@
              DIG 3 ;
              COMPARE ;
              GE ;
-             OR ;
+             AND ;
              OR ;
              NOT ;
              IF { NOW ;

--- a/packages/minter-contracts/bin/english_auction_tez_permit.tz
+++ b/packages/minter-contracts/bin/english_auction_tez_permit.tz
@@ -491,7 +491,7 @@
                          DIG 3 ;
                          COMPARE ;
                          GE ;
-                         OR ;
+                         AND ;
                          OR ;
                          NOT ;
                          IF { NOW ;

--- a/packages/minter-contracts/bin/english_auction_tez_permit_allowlisted.tz
+++ b/packages/minter-contracts/bin/english_auction_tez_permit_allowlisted.tz
@@ -491,7 +491,7 @@
                          DIG 3 ;
                          COMPARE ;
                          GE ;
-                         OR ;
+                         AND ;
                          OR ;
                          NOT ;
                          IF { NOW ;

--- a/packages/minter-contracts/bin/english_auction_tez_permit_allowlisted_token.tz
+++ b/packages/minter-contracts/bin/english_auction_tez_permit_allowlisted_token.tz
@@ -497,7 +497,7 @@
                          DIG 3 ;
                          COMPARE ;
                          GE ;
-                         OR ;
+                         AND ;
                          OR ;
                          NOT ;
                          IF { NOW ;

--- a/packages/minter-contracts/ligo/src/english_auction/english_auction_tez.mligo
+++ b/packages/minter-contracts/ligo/src/english_auction/english_auction_tez.mligo
@@ -135,8 +135,8 @@ let dont_return_bid (auction : auction) : bool =
 #endif
 
 let valid_bid_amount (auction, bid_amount : auction * tez) : bool =
-  (bid_amount >= (auction.current_bid + (percent_of_bid_tez (auction.min_raise_percent, auction.current_bid)))) ||
-  (bid_amount >= auction.current_bid + auction.min_raise)                                            ||
+  ((bid_amount >= (auction.current_bid + (percent_of_bid_tez (auction.min_raise_percent, auction.current_bid)))) &&
+  (bid_amount >= auction.current_bid + auction.min_raise))                                            ||
   ((bid_amount >= auction.current_bid) && first_bid(auction))
 
 


### PR DESCRIPTION
In the past version of english auction contracts, a subsequent bid needed to be greater than either the `min_raise_percent` of the previous bid, **OR** it needed to be greater than the sum of the previous bid and the `min_raise`. This PR changes the logic to be **AND** instead of **OR**. In other words, a new bid must satisfy both the percentage raise requirements as well as the min raise logic.